### PR TITLE
Allow setting SELinux mode when SELinux is disabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,9 +14,6 @@
     state: present
   when: ansible_distribution == "Fedora"
 
-- name: Drop all local modifications first
-  shell: echo "{{drop_local_modifications}}" | /usr/sbin/semanage -i -
-
 - name: Set permanent SELinux mode
   selinux: policy={{ SELinux_type }} state={{ SELinux_mode }}
   when: SELinux_mode is defined
@@ -24,6 +21,13 @@
 - name: Set running SELinux mode
   command: /usr/sbin/setenforce {{ SELinux_mode }}
   when: SELinux_mode is defined and SELinux_change_running is defined
+
+- name: Drop all local modifications
+  shell: echo "{{drop_local_modifications}}" | /usr/sbin/semanage -i -
+
+- name: Reload SELinux policy
+  command: semodule -R
+  when: ansible_selinux.status != "disabled"
 
 - name: Set SELinux booleans
   seboolean:

--- a/test/selinux.config
+++ b/test/selinux.config
@@ -1,0 +1,14 @@
+
+# This file controls the state of SELinux on the system.
+# SELINUX= can take one of these three values:
+#     enforcing - SELinux security policy is enforced.
+#     permissive - SELinux prints warnings instead of enforcing.
+#     disabled - No SELinux policy is loaded.
+SELINUX=disabled
+# SELINUXTYPE= can take one of these three values:
+#     targeted - Targeted processes are protected,
+#     minimum - Modification of targeted policy. Only selected processes are protected. 
+#     mls - Multi Level Security protection.
+SELINUXTYPE=targeted
+
+

--- a/test/test_selinux_disabled.yml
+++ b/test/test_selinux_disabled.yml
@@ -1,0 +1,48 @@
+
+- name: Ensure the default is targeted, enforcing, without local modifications
+  hosts: all
+  become: true
+  vars:
+    SELinux_type: targeted
+    SELinux_mode: enforcing
+
+  pre_tasks:
+    - name: Backup original /etc/selinux/config
+      copy:
+        remote_src: true
+        src: /etc/selinux/config
+        dest: /etc/selinux/config.test_selinux_disabled
+    - name: Upload testing /etc/selinux/config
+      copy:
+        src: selinux.config
+        dest: /etc/selinux/config
+    - name: Switch to permissive to allow login when selinuxfs is not mounted
+      command: setenforce 0
+      when: ansible_selinux.status != "disabled"
+    - name: Get selinuxfs mountpoint
+      shell: findmnt -n -t selinuxfs --output=target
+      register: selinux_mountpoint
+    - name: Umount {{ selinux_mountpoint.stdout }} to emulate SELinux disabled system
+      command: umount {{ selinux_mountpoint.stdout }}
+
+  roles:
+    - selinux
+
+  tasks:
+    - name: Mount {{ selinux_mountpoint.stdout }} back to system
+      command: mount -t selinuxfs selinuxfs {{ selinux_mountpoint.stdout }}
+    - name: Switch back to enforcing
+      command: setenforce 1
+    - name: Gather facts again
+      setup:
+    - name: Check SELinux config mode
+      assert:
+        that: "{{ ansible_selinux.config_mode == 'enforcing' }}"
+        mgs: "SELinux config mode should be enforcing instead of {{ ansible_selinux.config_mode }}"
+    - name: Restore original /etc/selinux/config
+      copy:
+        remote_src: true
+        dest: /etc/selinux/config
+        src: /etc/selinux/config.test_selinux_disabled
+    - name: Remove /etc/selinux/config backup
+      command: rm /etc/selinux/config.test_selinux_disabled

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 drop_local_modifications: |
-  boolean -D
-  login -D
-  port -D
-  fcontext -D
+  boolean -D -N
+  login -D -N
+  port -D -N
+  fcontext -D -N


### PR DESCRIPTION
When SELinux is disabled some operations like policy reload can't be
done therefore we need to:

- Change the permanent SELinux mode first

- Use '-N' option in 'semanage' import commands in order to avoid
automatic policy reloading

- Reload policy only if SELinux is not disabled


The new order of steps used in the role is:

1. Install SELinux tools
2. Set permanent SELinux mode via /etc/selinux/config
3. Set running SELinux mode - works only when SELinux is not disabled
4. Drop all local modifications - this is the place where '-N' option is added so that it works with SELinux disabled
5. Reload SELinux policy - only if SELinux is not disabled
6. Set SELinux file contexts, booleans and so on - all of them don't work with SELinux disabled due to limitations in Ansible modules

Fixes: https://github.com/linux-system-roles/selinux/issues/1