### PR TITLE
Fix policy reload problem on CentOS 6 and update tests

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
   when: SELinux_mode is defined and SELinux_change_running is defined
 
 - name: Drop all local modifications
-  shell: echo "{{drop_local_modifications}}" | /usr/sbin/semanage -i -
+  shell: echo -e -n "{{drop_local_modifications}}" | /usr/sbin/semanage -i -
 
 - name: Reload SELinux policy
   command: semodule -R

--- a/test/test_boolean.yml
+++ b/test/test_boolean.yml
@@ -5,8 +5,7 @@
 
   vars:
     SELinux_booleans:
-      - { name: 'samba_enable_home_dirs', state: 'on' }
-      - { name: 'ssh_sysadm_login', state: 'on', persistent: 'yes' }
+      - { name: 'samba_enable_home_dirs', state: 'on', persistent: 'yes' }
 
   roles:
     - selinux
@@ -16,4 +15,8 @@
     - name: Check if there are SELinux boolean changes
       assert:
         that: "{{ selinux_role_boolean.stdout != '' }}"
-
+    - name: Cleanup booleans
+      seboolean:
+        name: "samba_enable_home_dirs"
+        state: "off"
+        persistent: "yes"

--- a/test/test_fcontext.yml
+++ b/test/test_fcontext.yml
@@ -15,3 +15,5 @@
     - name: Check if there are SELinux fcontext mapping changes
       assert:
         that: "{{ selinux_role_fcontext.stdout != '' }}"
+    - name: Cleanup file contexts
+      command: /usr/sbin/semanage fcontext -D

--- a/test/test_login.yml
+++ b/test/test_login.yml
@@ -28,4 +28,6 @@
         comment: System Api Roles SELinux User
         name: sar-user
         state: absent
+    - name: Cleanup login mappings
+      command: /usr/sbin/semanage login -D
 

--- a/test/test_port.yml
+++ b/test/test_port.yml
@@ -15,3 +15,5 @@
     - name: Check if there are SELinux port mapping changes
       assert:
         that: "{{ selinux_role_port.stdout != '' }}"
+    - name: Cleanup port mappings
+      command: /usr/sbin/semanage port -D

--- a/test/test_selinux_disabled.yml
+++ b/test/test_selinux_disabled.yml
@@ -5,8 +5,26 @@
   vars:
     SELinux_type: targeted
     SELinux_mode: enforcing
+    semanage_change: |
+      boolean -m --on samba_enable_home_dirs
+      port -a -p tcp -t ssh_port_t 22100
+      fcontext -a -t user_home_dir_t /tmp/test_dir
+      login -a -s staff_u sar-user
 
   pre_tasks:
+    - name: Install SELinux tool semanage on Fedora
+      package:
+        name:
+          - policycoreutils-python-utils
+        state: present
+      when: ansible_distribution == "Fedora"
+
+    - name: Add a System Api Roles SELinux User
+      user:
+        comment: System Api Roles SELinux User
+        name: sar-user
+    - name: Add some mapping
+      shell: echo -e -n "{{ semanage_change }}" | /usr/sbin/semanage -i -
     - name: Backup original /etc/selinux/config
       copy:
         remote_src: true
@@ -46,3 +64,8 @@
         src: /etc/selinux/config.test_selinux_disabled
     - name: Remove /etc/selinux/config backup
       command: rm /etc/selinux/config.test_selinux_disabled
+    - name: Remove System Api Roles SELinux User
+      user:
+        name: sar-user
+        remove: yes
+        state: absent


### PR DESCRIPTION
'semanage -i -' command CentOS 6 and Red Hat Enterprise Linux 6 has a
bug which resets 'noreload' global variable every time a new line is
read even when the line is empty. E.g. for

echo "fcontext -D -N\n" | semanage -i -

Since echo adds another '\n' at the end of the string it means that the
empty line at the end of the input string changes the value of
'noreload' to True and semanage tries to reload policy and it fail as
SELinux is disabled. Note: while the variable is called 'noreload' it
has the opposite meaning.

Fixes: #3

At the same time, tests are being updated to cleanup when pass and  `test_selinux_disabled` has been enhanced to cover issue #3