### PR TITLE
Drop selinux_change_running variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,11 @@ roles:
 ```
 
 
-#### set SELinux mode permanently and in running system
+#### set SELinux policy type and mode
 
 ```yaml
 selinux_policy: targeted
 selinux_state: enforcing
-selinux_change_running: 1
 ```
 
 #### set SELinux booleans

--- a/selinux-playbook.yml
+++ b/selinux-playbook.yml
@@ -6,7 +6,6 @@
   vars:
     selinux_policy: targeted
     selinux_state: enforcing
-    selinux_change_running: 1
     selinux_booleans:
       - { name: 'samba_enable_home_dirs', state: 'on' }
       - { name: 'ssh_sysadm_login', state: 'on', persistent: 'yes' }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,10 +18,6 @@
   selinux: policy={{ selinux_policy }} state={{ selinux_state }}
   when: selinux_state is defined
 
-- name: Set running SELinux state
-  command: /usr/sbin/setenforce {{ selinux_state }}
-  when: selinux_state is defined and selinux_change_running is defined
-
 - name: Drop all local modifications
   shell: echo -e -n "{{drop_local_modifications}}" | /usr/sbin/semanage -i -
 


### PR DESCRIPTION
Apparently, selinux module changes the current (running) state together with the
permanent state therefore this variable seems to be pointless, see
https://bugzilla.redhat.com/show_bug.cgi?id=1602872#c0