### PR TITLE
Handle selinux_state and selinux_policy variables if there are not defined.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,9 +24,21 @@
     ( ansible_distribution_major_version > "7" and
       ( ansible_distribution == "CentOS" or ansible_distribution == "RedHat" ))
 
-- name: Set permanent SELinux state
-  selinux: policy={{ selinux_policy }} state={{ selinux_state }}
-  when: selinux_state is defined
+- name: Set permanent SELinux state if enabled
+  selinux:
+    state: "{{ selinux_state | default(ansible_selinux.config_mode) }}"
+    policy: "{{ selinux_policy | default(ansible_selinux.type) }}"
+  when: ansible_selinux.status == "enabled"
+
+- name: Set permanent SELinux state if disabled
+  selinux:
+    state: "{{ selinux_state }}"
+    policy: "{{ selinux_policy | default('targeted') }}"
+  when: ansible_selinux.status == "disabled" and selinux_state is defined
+
+- debug:
+    msg: "SELinux is disabled on system - some SELinux modules can crash"
+  when: ansible_selinux.status == "disabled"
 
 - name: Drop all local modifications
   shell: echo -e -n "{{drop_local_modifications}}" | /usr/sbin/semanage -i -


### PR DESCRIPTION
If these variables are not defined, will be used current value from
Ansible facts from ansible node.

- selinux_state using ansible_selinux.config_mode
- selinux_policy using ansible_selinux.type

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1602897
https://bugzilla.redhat.com/show_bug.cgi?id=1602901