### PR TITLE
Update tests for SELinux role.

### DIFF
--- a/tests/tests_boolean.yml
+++ b/tests/tests_boolean.yml
@@ -6,6 +6,7 @@
   vars:
     selinux_booleans:
       - { name: 'samba_enable_home_dirs', state: 'on', persistent: 'yes' }
+    selinux_booleans_purge: true
 
   roles:
     - selinux

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -5,7 +5,8 @@
 
   roles:
     - selinux
-
+  vars:
+      selinux_all_purge: true
   tasks:
     - name: Gather facts again
       setup:

--- a/tests/tests_fcontext.yml
+++ b/tests/tests_fcontext.yml
@@ -4,6 +4,7 @@
   become: true
 
   vars:
+    selinux_all_purge: true
     selinux_fcontexts:
       - { target: '/tmp/test_dir(/.*)?', setype: 'user_home_dir_t', ftype: 'd' }
 

--- a/tests/tests_login.yml
+++ b/tests/tests_login.yml
@@ -4,6 +4,7 @@
   become: true
 
   vars:
+    selinux_logins_purge: true
     selinux_logins:
       - { login: 'sar-user', seuser: 'staff_u', serange: 's0-s0:c0.c1023', state: 'present' }
 

--- a/tests/tests_port.yml
+++ b/tests/tests_port.yml
@@ -4,6 +4,7 @@
   become: true
 
   vars:
+    selinux_ports_purge: true
     selinux_ports:
       - { ports: '22100', proto: 'tcp', setype: 'ssh_port_t', state: 'present' }
 

--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -3,6 +3,7 @@
   hosts: all
   become: true
   vars:
+    selinux_all_purge: true
     selinux_policy: targeted
     selinux_state: enforcing
     semanage_change: |


### PR DESCRIPTION
selinux_*_purge variables was added, which means you need to specify
right variable to drop local modifications. This patch fixing our tests.