### PR TITLE
Fix tests_selinux_disabled.yml

### DIFF
--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -11,7 +11,7 @@
       fcontext -a -t user_home_dir_t /tmp/test_dir
       login -a -s staff_u sar-user
 
-  pre_tasks:
+  tasks:
     - name: Install SELinux tool semanage on Fedora
       package:
         name:
@@ -43,10 +43,19 @@
     - name: Umount {{ selinux_mountpoint.stdout }} to emulate SELinux disabled system
       command: umount {{ selinux_mountpoint.stdout }}
 
-  roles:
-    - selinux
+    - name: execute the role and catch errors
+      block:
+        - include_role:
+            name: selinux
+      rescue:
+        - name: examine the selinux_reboot_required variable
+          set_fact:
+            test_selinux_reboot_required: "{{ selinux_reboot_required }}"
 
-  tasks:
+    - name: check that the role has failed and set the correct variable
+      assert:
+        that: "{{ test_selinux_reboot_required }}"
+        msg: "test_selinux_reboot_required should be True instead of {{ test_selinux_reboot_required }}"
     - name: Mount {{ selinux_mountpoint.stdout }} back to system
       command: mount -t selinuxfs selinuxfs {{ selinux_mountpoint.stdout }}
     - name: Switch back to enforcing
@@ -63,8 +72,10 @@
         dest: /etc/selinux/config
         src: /etc/selinux/config.test_selinux_disabled
     - name: Remove /etc/selinux/config backup
-      command: rm /etc/selinux/config.test_selinux_disabled
-    - name: Remove System Api Roles SELinux User
+      file:
+        path: /etc/selinux/config.test_selinux_disabled
+        state: absent
+    - name: Remove Linux System Roles SELinux User
       user:
         name: sar-user
         remove: yes


### PR DESCRIPTION
The role nowadays fails if it finds out that the machine needs to be rebooted.
Adapt the test to this and check that the role has indeed failed and has set the correct variable.

Other minor corrections.