### PR TITLE
Cleanup after tests_all_transitions.yml

### DIFF
--- a/tests/selinux_config_restore.yml
+++ b/tests/selinux_config_restore.yml
@@ -1,0 +1,25 @@
+- name: Restore original /etc/selinux/config
+  copy:
+    remote_src: true
+    dest: /etc/selinux/config
+    src: /etc/selinux/config.test_selinux_save
+  register: restoreconf
+
+- name: Remove /etc/selinux/config backup
+  file:
+    path: /etc/selinux/config.test_selinux_save
+    state: absent
+
+- name: reboot
+  block:
+    - name: restart managed host
+      shell: sleep 2 && shutdown -r now "Ansible updates triggered"
+      async: 1
+      poll: 0
+      ignore_errors: true
+
+    - name: wait for managed host to come back
+      wait_for_connection:
+        delay: 10
+        timeout: 120
+  when: restoreconf is changed

--- a/tests/selinux_config_save.yml
+++ b/tests/selinux_config_save.yml
@@ -1,0 +1,5 @@
+- name: Backup original /etc/selinux/config
+  copy:
+    remote_src: true
+    src: /etc/selinux/config
+    dest: /etc/selinux/config.test_selinux_save

--- a/tests/tests_all_transitions.yml
+++ b/tests/tests_all_transitions.yml
@@ -8,6 +8,9 @@
       - disabled
 
   tasks:
+    - name: save config
+      include_tasks: selinux_config_save.yml
+
     - name: test all the possible state transitions
       include_tasks: selinux_test_transitions.yml
       vars:
@@ -16,3 +19,7 @@
       with_nested:
         - "{{ states }}"
         - "{{ states }}"
+
+    - name: restore config
+      include_tasks: selinux_config_restore.yml
+


### PR DESCRIPTION
tests_all_transitions.yml used to leave SELinux in a disabled state.
This was a problem if more tests are running after it, so save state at the
beginning and restore it to the original state after the test is done. This
allows all the tests to be run on a single VM, saving initializations.