### PR TITLE
Fix yamllint errors

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,14 +1,26 @@
 galaxy_info:
   author: Petr Lautrbach <plautrba@redhat.com>
   description: Configure SELinux
-  galaxy_tags: [ 'system', 'selinux', 'redhat', 'rhel', 'fedora', 'centos' ]
+  galaxy_tags:
+    - system
+    - selinux
+    - redhat
+    - rhel
+    - fedora
+    - centos
   company: Red Hat, Inc.
   license: GPL-3.0+
   min_ansible_version: 2.5
   platforms:
-  - name: Fedora
-    versions: [ 27, 28 ]
-  - name: EL
-    versions: [ 6, 7 ]
+    - name: Fedora
+      versions:
+        - 28
+        - 29
+        - 30
+    - name: EL
+      versions:
+        - 6
+        - 7
+        - 8
 
 allow_duplicates: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,23 +58,25 @@
   when: ansible_selinux.status == "disabled"
 
 - name: Drop all local modifications
-  shell: echo -e -n "{{drop_local_modifications}}" | /usr/sbin/semanage -i -
+  command: /usr/sbin/semanage -i -
+  args:
+    stdin: "{{ drop_local_modifications }}"
   when: selinux_all_purge | bool
 
 - name: Purge all SELinux boolean local modifications
-  shell: /usr/sbin/semanage boolean -D
+  command: /usr/sbin/semanage boolean -D
   when: selinux_booleans_purge | bool
 
 - name: Purge all SELinux file context local modifications
-  shell: /usr/sbin/semanage fcontext -D
+  command: /usr/sbin/semanage fcontext -D
   when: selinux_fcontexts_purge | bool
 
 - name: Purge all SELinux port local modifications
-  shell: /usr/sbin/semanage port -D
+  command: /usr/sbin/semanage port -D
   when: selinux_ports_purge | bool
 
 - name: Purge all SELinux login local modifications
-  shell: /usr/sbin/semanage login -D
+  command: /usr/sbin/semanage login -D
   when: selinux_logins_purge | bool
 
 - name: Reload SELinux policy
@@ -92,14 +94,24 @@
   sefcontext:
     target: "{{ item.target }}"
     setype: "{{ item.setype }}"
-    ftype:  "{{ item.ftype | default('a') }}"
-    state:  "{{ item.state | default('present') }}"
+    ftype: "{{ item.ftype | default('a') }}"
+    state: "{{ item.state | default('present') }}"
     # FIXME: selevel, seuser
   with_items: "{{ selinux_fcontexts }}"
 
 - name: Restore SELinux labels on filesystem tree
-  command: /sbin/restorecon -R {{ item }}
+  command: /sbin/restorecon -R -v {{ item }}
   with_items: "{{ selinux_restore_dirs }}"
+  register: restorecon_cmd
+  changed_when: '"Relabeled" in restorecon_cmd.stdout'
+
+- name: Restore SELinux labels on filesystem tree in check mode
+  command: /sbin/restorecon -R -v -n {{ item }}
+  with_items: "{{ selinux_restore_dirs }}"
+  register: restorecon_cmd
+  changed_when: '"Would relabel" in restorecon_cmd.stdout'
+  check_mode: no
+  when: ansible_check_mode
 
 - name: Set an SELinux label on a port
   seport:

--- a/tests/selinux_apply_reboot.yml
+++ b/tests/selinux_apply_reboot.yml
@@ -18,4 +18,4 @@
     - name: wait for managed host to come back
       wait_for_connection:
         delay: 10
-        timeout: 120
+        timeout: 300

--- a/tests/selinux_config_restore.yml
+++ b/tests/selinux_config_restore.yml
@@ -21,5 +21,5 @@
     - name: wait for managed host to come back
       wait_for_connection:
         delay: 10
-        timeout: 120
+        timeout: 300
   when: restoreconf is changed


### PR DESCRIPTION
Fixes indentation in role's metadata:
--> Executing Yamllint on files found in selinux/...
    selinux/meta/main.yml
      9:3       error    wrong indentation: expected 4 but found 2  (indentation)

Fixes too many spaces after colon in the 'Set SELinux file contexts' task:
    selinux/tasks/main.yml
      95:12     error    too many spaces after colon  (colons)
      96:12     error    too many spaces after colon  (colons)