### PR TITLE
Add test running the role with default parameters

### DIFF
--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,0 +1,6 @@
+
+- name: Ensure that the role runs with default parameters
+  hosts: all
+
+  roles:
+    - selinux


### PR DESCRIPTION
The idea is to run this default test with Molecule and Travis to do basic checks like in currently proposed change for timesync:
https://github.com/linux-system-roles/timesync/pull/33