### PR TITLE
List all variables in defaults.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+selinux_state: null
+selinux_policy: null
 
 # Set up empty lists for SELinux changes.
 selinux_booleans: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,17 +30,17 @@
 
 - name: Set permanent SELinux state if enabled
   selinux:
-    state: "{{ selinux_state | default(ansible_selinux.config_mode) }}"
-    policy: "{{ selinux_policy | default(ansible_selinux.type) }}"
+    state: "{{ selinux_state | default(ansible_selinux.config_mode, true) }}"
+    policy: "{{ selinux_policy | default(ansible_selinux.type, true) }}"
   register: selinux_mod_output_enabled
-  when: ansible_selinux.status == "enabled" and ( selinux_state is defined or selinux_policy is defined )
+  when: ansible_selinux.status == "enabled" and ( selinux_state or selinux_policy )
 
 - name: Set permanent SELinux state if disabled
   selinux:
     state: "{{ selinux_state }}"
-    policy: "{{ selinux_policy | default('targeted') }}"
+    policy: "{{ selinux_policy | default('targeted', true) }}"
   register: selinux_mod_output_disabled
-  when: ansible_selinux.status == "disabled" and selinux_state is defined
+  when: ansible_selinux.status == "disabled" and selinux_state
 
 - name: Set ansible facts if needed
   set_fact:

--- a/tests/tests_default_vars.yml
+++ b/tests/tests_default_vars.yml
@@ -1,0 +1,21 @@
+- name: Ensure that the role declares all paremeters in defaults
+  hosts: all
+
+  roles:
+    - selinux
+  tasks:
+    - assert:
+        that: "vars[item] is defined"
+      loop:
+        - selinux_state
+        - selinux_policy
+        - selinux_booleans
+        - selinux_fcontexts
+        - selinux_logins
+        - selinux_ports
+        - selinux_restore_dirs
+        - selinux_all_purge
+        - selinux_booleans_purge
+        - selinux_fcontexts_purge
+        - selinux_ports_purge
+        - selinux_logins_purge


### PR DESCRIPTION
Those whose absence had a special meaning have a default value of null.

The second argument to the default() Jinjs2 filter was used to compensate for
the change: it causes the variable to be substituted if evaluates to false
(instead of just if undefined).

This helps using the role in Foreman/Satellite, because those introspect the
role's defaults file to know what parameters the role takes and present it to
the user. (So far, there has been no other way to declare role's input
parameters.)