### PR TITLE
use tox for ansible-lint instead of molecule

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,7 @@ jobs:
           toxenvs="py${toxpyver}"
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint,custom" ;;
-          36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck,custom,collection" ;;
+          36) toxenvs="${toxenvs},coveralls,black,yamllint,ansible-lint,shellcheck,custom,collection" ;;
           37) toxenvs="${toxenvs},coveralls,custom" ;;
           38) toxenvs="${toxenvs},coveralls,custom" ;;
           esac

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,6 +6,7 @@ driver:
   name: docker
 lint:
   name: yamllint
+  enabled: false
   options:
     config-file: .yamllint.yml
 platforms:
@@ -21,6 +22,7 @@ provisioner:
   name: ansible
   log: true
   lint:
+    enabled: false
     name: ansible-lint
   playbooks:
     converge: ../../tests/tests_default.yml
@@ -37,3 +39,4 @@ verifier:
   name: testinfra
   lint:
     name: flake8
+    enabled: false

--- a/tests/set_selinux_variables.yml
+++ b/tests/set_selinux_variables.yml
@@ -1,13 +1,17 @@
 ---
 - name: Get local modifications - boolean
   command: /usr/sbin/semanage boolean -l -n -C
+  changed_when: false
   register: selinux_role_boolean
 - name: Get local modifications - port
   command: /usr/sbin/semanage port -l -n -C
+  changed_when: false
   register: selinux_role_port
 - name: Get local modifications - login
   command: /usr/sbin/semanage login -l -n -C
+  changed_when: false
   register: selinux_role_login
 - name: Get local modifications - fcontext
   command: /usr/sbin/semanage fcontext -l -n -C
+  changed_when: false
   register: selinux_role_fcontext

--- a/tests/tests_all_purge.yml
+++ b/tests/tests_all_purge.yml
@@ -23,6 +23,7 @@
 
     - name: Add some mapping
       shell: echo -e -n "{{ semanage_change }}" | /usr/sbin/semanage -i -
+      changed_when: false
 
     - name: Apply role with defaults, should not drop local modifications
       include_role:

--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -25,6 +25,7 @@
         name: sar-user
     - name: Add some mapping
       shell: echo -e -n "{{ semanage_change }}" | /usr/sbin/semanage -i -
+      changed_when: false
     - name: Backup original /etc/selinux/config
       copy:
         remote_src: true
@@ -36,12 +37,15 @@
         dest: /etc/selinux/config
     - name: Switch to permissive to allow login when selinuxfs is not mounted
       command: setenforce 0
+      changed_when: false
       when: ansible_selinux.status != "disabled"
-    - name: Get selinuxfs mountpoint
+    - name: Get selinuxfs mountpoint  # noqa 305
       shell: findmnt -n -t selinuxfs --output=target
+      changed_when: false
       register: selinux_mountpoint
-    - name: Umount {{ selinux_mountpoint.stdout }} to emulate SELinux disabled system
+    - name: Umount {{ selinux_mountpoint.stdout }} to emulate SELinux disabled system  # noqa 303
       command: umount {{ selinux_mountpoint.stdout }}
+      changed_when: false
 
     - name: execute the role and catch errors
       block:
@@ -56,10 +60,12 @@
       assert:
         that: "{{ test_selinux_reboot_required }}"
         msg: "test_selinux_reboot_required should be True instead of {{ test_selinux_reboot_required }}"
-    - name: Mount {{ selinux_mountpoint.stdout }} back to system
+    - name: Mount {{ selinux_mountpoint.stdout }} back to system  # noqa 303
       command: mount -t selinuxfs selinuxfs {{ selinux_mountpoint.stdout }}
+      changed_when: false
     - name: Switch back to enforcing
       command: setenforce 1
+      changed_when: false
     - name: Gather facts again
       setup:
     - name: Check SELinux config mode


### PR DESCRIPTION
Deprecate the use of molecule for linting.  Use tox for ansible-lint.
The next step will be to remove the ansible-lint dependency from
the molecule environments.