### PR TITLE
use reboot module; ansible 2.8

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
     - centos
   company: Red Hat, Inc.
   license: GPL-3.0+
-  min_ansible_version: 2.5
+  min_ansible_version: 2.8
   platforms:
     - name: Fedora
       versions:

--- a/tests/selinux_apply_reboot.yml
+++ b/tests/selinux_apply_reboot.yml
@@ -10,12 +10,8 @@
       when: not selinux_reboot_required
 
     - name: restart managed host
-      shell: sleep 2 && shutdown -r now "Ansible updates triggered"
-      async: 1
-      poll: 0
-      ignore_errors: true
-
-    - name: wait for managed host to come back
-      wait_for_connection:
-        delay: 10
-        timeout: 300
+      reboot:
+        msg: Ansible updates triggered
+        pre_reboot_delay: 2
+        post_reboot_delay: 10
+        reboot_timeout: 300


### PR DESCRIPTION
Use the `reboot` module to restart the machine and wait for it to
come back, rather than `shell` and a separate wait task.
Change `min_ansible_version` to 2.8