### PR TITLE
CI: Add support for RHEL-9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,5 +20,6 @@ galaxy_info:
         - 6
         - 7
         - 8
+        - 9
 
 allow_duplicates: true


### PR DESCRIPTION
From now the `rhel-8-y` status is the latest unreleased RHEL-8 and the `rhel-x` status is pre-released RHEL-9.