### PR TITLE
RHELPLAN-69928  Add a note to each module Doc to indicate it is private

### DIFF
--- a/library/selinux_modules_facts.py
+++ b/library/selinux_modules_facts.py
@@ -14,7 +14,9 @@ short_description: Gather state of SELinux modules
 
 version_added: '0.0.1'
 
-description: Gather state of SELinux modules
+description:
+    - "WARNING: Do not use this module directly! It is only for role internal use."
+    - Gather state of SELinux modules
 
 author:
     - Petr Lautrbach (@bachradsusi)

--- a/library/selogin.py
+++ b/library/selogin.py
@@ -30,7 +30,8 @@ DOCUMENTATION = r"""
 module: selogin
 short_description: Manages linux user to SELinux user mapping
 description:
-     - Manages linux user to SELinux user mapping
+    - "WARNING: Do not use this module directly! It is only for role internal use."
+    - Manages linux user to SELinux user mapping
 version_added: '1.0'
 options:
   login:


### PR DESCRIPTION
Adding "WARNING: Do not use this module directly! It is only for role internal use." to selogin and selinux_modules_facts module DOCUMENTATION.

Divided into 2 commits to make it easier to create a patch.