### PR TITLE
use lazy unmount to fix umount: target is busy

### DIFF
--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -51,7 +51,7 @@
       register: selinux_mountpoint
     - name: "Umount {{ selinux_mountpoint.stdout }} to emulate SELinux
       disabled system  # noqa 303"
-      command: umount {{ selinux_mountpoint.stdout }}
+      command: umount -l {{ selinux_mountpoint.stdout }}
       changed_when: false
 
     - name: execute the role and catch errors


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1945359
EL9 changed the behavior with respect to mounts, so use lazy
unmount when umounting /sys/fs/selinux
It is safe to do this on all platforms.