### PR TITLE
use tox-lsr version 2.5.1

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.4.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.5.1"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default


### PR DESCRIPTION
This version removes support for molecule until we can figure out
what to do about molecule.  This should make all of the tox tests
pass (except for python 2.6).