### PR TITLE
Bundling community.general.{sefcontext,selogin,seport} modules

### DIFF
--- a/library/sefcontext.py
+++ b/library/sefcontext.py
@@ -1,0 +1,338 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2016, Dag Wieers (@dagwieers) <dag@wieers.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: sefcontext
+short_description: Manages SELinux file context mapping definitions
+description:
+- Manages SELinux file context mapping definitions.
+- Similar to the C(semanage fcontext) command.
+options:
+  target:
+    description:
+    - Target path (expression).
+    type: str
+    required: yes
+    aliases: [ path ]
+  ftype:
+    description:
+    - The file type that should have SELinux contexts applied.
+    - "The following file type options are available:"
+    - C(a) for all files,
+    - C(b) for block devices,
+    - C(c) for character devices,
+    - C(d) for directories,
+    - C(f) for regular files,
+    - C(l) for symbolic links,
+    - C(p) for named pipes,
+    - C(s) for socket files.
+    type: str
+    choices: [ a, b, c, d, f, l, p, s ]
+    default: a
+  setype:
+    description:
+    - SELinux type for the specified target.
+    type: str
+    required: yes
+  seuser:
+    description:
+    - SELinux user for the specified target.
+    type: str
+  selevel:
+    description:
+    - SELinux range for the specified target.
+    type: str
+    aliases: [ serange ]
+  state:
+    description:
+    - Whether the SELinux file context must be C(absent) or C(present).
+    type: str
+    choices: [ absent, present ]
+    default: present
+  reload:
+    description:
+    - Reload SELinux policy after commit.
+    - Note that this does not apply SELinux file contexts to existing files.
+    type: bool
+    default: yes
+  ignore_selinux_state:
+    description:
+    - Useful for scenarios (chrooted environment) that you can't get the real SELinux state.
+    type: bool
+    default: no
+notes:
+- The changes are persistent across reboots.
+- The M(community.general.sefcontext) module does not modify existing files to the new
+  SELinux context(s), so it is advisable to first create the SELinux
+  file contexts before creating files, or run C(restorecon) manually
+  for the existing files that require the new SELinux file contexts.
+- Not applying SELinux fcontexts to existing files is a deliberate
+  decision as it would be unclear what reported changes would entail
+  to, and there's no guarantee that applying SELinux fcontext does
+  not pick up other unrelated prior changes.
+requirements:
+- libselinux-python
+- policycoreutils-python
+author:
+- Dag Wieers (@dagwieers)
+"""
+
+EXAMPLES = r"""
+- name: Allow apache to modify files in /srv/git_repos
+  community.general.sefcontext:
+    target: '/srv/git_repos(/.*)?'
+    setype: httpd_git_rw_content_t
+    state: present
+
+- name: Apply new SELinux file context to filesystem
+  ansible.builtin.command: restorecon -irv /srv/git_repos
+"""
+
+RETURN = r"""
+# Default return values
+"""
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.common.text.converters import to_native
+
+SELINUX_IMP_ERR = None
+try:
+    import selinux
+
+    HAVE_SELINUX = True
+except ImportError:
+    SELINUX_IMP_ERR = traceback.format_exc()
+    HAVE_SELINUX = False
+
+SEOBJECT_IMP_ERR = None
+try:
+    import seobject
+
+    HAVE_SEOBJECT = True
+except ImportError:
+    SEOBJECT_IMP_ERR = traceback.format_exc()
+    HAVE_SEOBJECT = False
+
+# Add missing entries (backward compatible)
+if HAVE_SEOBJECT:
+    seobject.file_types.update(
+        a=seobject.SEMANAGE_FCONTEXT_ALL,
+        b=seobject.SEMANAGE_FCONTEXT_BLOCK,
+        c=seobject.SEMANAGE_FCONTEXT_CHAR,
+        d=seobject.SEMANAGE_FCONTEXT_DIR,
+        f=seobject.SEMANAGE_FCONTEXT_REG,
+        l=seobject.SEMANAGE_FCONTEXT_LINK,
+        p=seobject.SEMANAGE_FCONTEXT_PIPE,
+        s=seobject.SEMANAGE_FCONTEXT_SOCK,
+    )
+
+# Make backward compatible
+option_to_file_type_str = dict(
+    a="all files",
+    b="block device",
+    c="character device",
+    d="directory",
+    f="regular file",
+    l="symbolic link",
+    p="named pipe",
+    s="socket",
+)
+
+
+def get_runtime_status(ignore_selinux_state=False):
+    return True if ignore_selinux_state is True else selinux.is_selinux_enabled()
+
+
+def semanage_fcontext_exists(sefcontext, target, ftype):
+    """Get the SELinux file context mapping definition from policy. Return None if it does not exist."""
+
+    # Beware that records comprise of a string representation of the file_type
+    record = (target, option_to_file_type_str[ftype])
+    records = sefcontext.get_all()
+    try:
+        return records[record]
+    except KeyError:
+        return None
+
+
+def semanage_fcontext_modify(
+    module, result, target, ftype, setype, do_reload, serange, seuser, sestore=""
+):
+    """Add or modify SELinux file context mapping definition to the policy."""
+
+    changed = False
+    prepared_diff = ""
+
+    try:
+        sefcontext = seobject.fcontextRecords(sestore)
+        sefcontext.set_reload(do_reload)
+        exists = semanage_fcontext_exists(sefcontext, target, ftype)
+        if exists:
+            # Modify existing entry
+            orig_seuser, orig_serole, orig_setype, orig_serange = exists
+
+            if seuser is None:
+                seuser = orig_seuser
+            if serange is None:
+                serange = orig_serange
+
+            if (
+                setype != orig_setype
+                or seuser != orig_seuser
+                or serange != orig_serange
+            ):
+                if not module.check_mode:
+                    sefcontext.modify(target, setype, ftype, serange, seuser)
+                changed = True
+
+                if module._diff:
+                    prepared_diff += "# Change to semanage file context mappings\n"
+                    prepared_diff += "-%s      %s      %s:%s:%s:%s\n" % (
+                        target,
+                        ftype,
+                        orig_seuser,
+                        orig_serole,
+                        orig_setype,
+                        orig_serange,
+                    )
+                    prepared_diff += "+%s      %s      %s:%s:%s:%s\n" % (
+                        target,
+                        ftype,
+                        seuser,
+                        orig_serole,
+                        setype,
+                        serange,
+                    )
+        else:
+            # Add missing entry
+            if seuser is None:
+                seuser = "system_u"
+            if serange is None:
+                serange = "s0"
+
+            if not module.check_mode:
+                sefcontext.add(target, setype, ftype, serange, seuser)
+            changed = True
+
+            if module._diff:
+                prepared_diff += "# Addition to semanage file context mappings\n"
+                prepared_diff += "+%s      %s      %s:%s:%s:%s\n" % (
+                    target,
+                    ftype,
+                    seuser,
+                    "object_r",
+                    setype,
+                    serange,
+                )
+
+    except Exception as e:
+        module.fail_json(msg="%s: %s\n" % (e.__class__.__name__, to_native(e)))
+
+    if module._diff and prepared_diff:
+        result["diff"] = dict(prepared=prepared_diff)
+
+    module.exit_json(changed=changed, seuser=seuser, serange=serange, **result)
+
+
+def semanage_fcontext_delete(module, result, target, ftype, do_reload, sestore=""):
+    """Delete SELinux file context mapping definition from the policy."""
+
+    changed = False
+    prepared_diff = ""
+
+    try:
+        sefcontext = seobject.fcontextRecords(sestore)
+        sefcontext.set_reload(do_reload)
+        exists = semanage_fcontext_exists(sefcontext, target, ftype)
+        if exists:
+            # Remove existing entry
+            orig_seuser, orig_serole, orig_setype, orig_serange = exists
+
+            if not module.check_mode:
+                sefcontext.delete(target, ftype)
+            changed = True
+
+            if module._diff:
+                prepared_diff += "# Deletion to semanage file context mappings\n"
+                prepared_diff += "-%s      %s      %s:%s:%s:%s\n" % (
+                    target,
+                    ftype,
+                    exists[0],
+                    exists[1],
+                    exists[2],
+                    exists[3],
+                )
+
+    except Exception as e:
+        module.fail_json(msg="%s: %s\n" % (e.__class__.__name__, to_native(e)))
+
+    if module._diff and prepared_diff:
+        result["diff"] = dict(prepared=prepared_diff)
+
+    module.exit_json(changed=changed, **result)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            ignore_selinux_state=dict(type="bool", default=False),
+            target=dict(type="str", required=True, aliases=["path"]),
+            ftype=dict(
+                type="str", default="a", choices=list(option_to_file_type_str.keys())
+            ),
+            setype=dict(type="str", required=True),
+            seuser=dict(type="str"),
+            selevel=dict(type="str", aliases=["serange"]),
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            reload=dict(type="bool", default=True),
+        ),
+        supports_check_mode=True,
+    )
+    if not HAVE_SELINUX:
+        module.fail_json(
+            msg=missing_required_lib("libselinux-python"), exception=SELINUX_IMP_ERR
+        )
+
+    if not HAVE_SEOBJECT:
+        module.fail_json(
+            msg=missing_required_lib("policycoreutils-python"),
+            exception=SEOBJECT_IMP_ERR,
+        )
+
+    ignore_selinux_state = module.params["ignore_selinux_state"]
+
+    if not get_runtime_status(ignore_selinux_state):
+        module.fail_json(msg="SELinux is disabled on this host.")
+
+    target = module.params["target"]
+    ftype = module.params["ftype"]
+    setype = module.params["setype"]
+    seuser = module.params["seuser"]
+    serange = module.params["selevel"]
+    state = module.params["state"]
+    do_reload = module.params["reload"]
+
+    result = dict(target=target, ftype=ftype, setype=setype, state=state)
+
+    if state == "present":
+        semanage_fcontext_modify(
+            module, result, target, ftype, setype, do_reload, serange, seuser
+        )
+    elif state == "absent":
+        semanage_fcontext_delete(module, result, target, ftype, do_reload)
+    else:
+        module.fail_json(msg='Invalid value of argument "state": {0}'.format(state))
+
+
+if __name__ == "__main__":
+    main()

--- a/library/selogin.py
+++ b/library/selogin.py
@@ -1,0 +1,273 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Petr Lautrbach <plautrba@redhat.com>
+# Based on seport.py module (c) 2014, Dan Keder <dan.keder@gmail.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: selogin
+short_description: Manages linux user to SELinux user mapping
+description:
+     - Manages linux user to SELinux user mapping
+options:
+  login:
+    type: str
+    description:
+      - a Linux user
+    required: true
+  seuser:
+    type: str
+    description:
+      - SELinux user name
+  selevel:
+    type: str
+    aliases: [ serange ]
+    description:
+      - MLS/MCS Security Range (MLS/MCS Systems only) SELinux Range for SELinux login mapping defaults to the SELinux user record range.
+    default: s0
+  state:
+    type: str
+    description:
+      - Desired mapping value.
+    default: present
+    choices: [ 'present', 'absent' ]
+  reload:
+    description:
+      - Reload SELinux policy after commit.
+    type: bool
+    default: yes
+  ignore_selinux_state:
+    description:
+    - Run independent of selinux runtime state
+    type: bool
+    default: false
+notes:
+   - The changes are persistent across reboots
+   - Not tested on any debian based system
+requirements: [ 'libselinux', 'policycoreutils' ]
+author:
+- Dan Keder (@dankeder)
+- Petr Lautrbach (@bachradsusi)
+- James Cassell (@jamescassell)
+"""
+
+EXAMPLES = """
+- name: Modify the default user on the system to the guest_u user
+  community.general.selogin:
+    login: __default__
+    seuser: guest_u
+    state: present
+
+- name: Assign gijoe user on an MLS machine a range and to the staff_u user
+  community.general.selogin:
+    login: gijoe
+    seuser: staff_u
+    serange: SystemLow-Secret
+    state: present
+
+- name: Assign all users in the engineering group to the staff_u user
+  community.general.selogin:
+    login: '%engineering'
+    seuser: staff_u
+    state: present
+"""
+
+RETURN = r"""
+# Default return values
+"""
+
+
+import traceback
+
+SELINUX_IMP_ERR = None
+try:
+    import selinux
+
+    HAVE_SELINUX = True
+except ImportError:
+    SELINUX_IMP_ERR = traceback.format_exc()
+    HAVE_SELINUX = False
+
+SEOBJECT_IMP_ERR = None
+try:
+    import seobject
+
+    HAVE_SEOBJECT = True
+except ImportError:
+    SEOBJECT_IMP_ERR = traceback.format_exc()
+    HAVE_SEOBJECT = False
+
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.common.text.converters import to_native
+
+
+def semanage_login_add(module, login, seuser, do_reload, serange="s0", sestore=""):
+    """Add linux user to SELinux user mapping
+
+    :type module: AnsibleModule
+    :param module: Ansible module
+
+    :type login: str
+    :param login: a Linux User or a Linux group if it begins with %
+
+    :type seuser: str
+    :param proto: An SELinux user ('__default__', 'unconfined_u', 'staff_u', ...), see 'semanage login -l'
+
+    :type serange: str
+    :param serange: SELinux MLS/MCS range (defaults to 's0')
+
+    :type do_reload: bool
+    :param do_reload: Whether to reload SELinux policy after commit
+
+    :type sestore: str
+    :param sestore: SELinux store
+
+    :rtype: bool
+    :return: True if the policy was changed, otherwise False
+    """
+    try:
+        selogin = seobject.loginRecords(sestore)
+        selogin.set_reload(do_reload)
+        change = False
+        all_logins = selogin.get_all()
+        # module.fail_json(msg="%s: %s %s" % (all_logins, login, sestore))
+        # for local_login in all_logins:
+        if login not in all_logins.keys():
+            change = True
+            if not module.check_mode:
+                selogin.add(login, seuser, serange)
+        else:
+            if all_logins[login][0] != seuser or all_logins[login][1] != serange:
+                change = True
+                if not module.check_mode:
+                    selogin.modify(login, seuser, serange)
+
+    except (ValueError, KeyError, OSError, RuntimeError) as e:
+        module.fail_json(
+            msg="%s: %s\n" % (e.__class__.__name__, to_native(e)),
+            exception=traceback.format_exc(),
+        )
+
+    return change
+
+
+def semanage_login_del(module, login, seuser, do_reload, sestore=""):
+    """Delete linux user to SELinux user mapping
+
+    :type module: AnsibleModule
+    :param module: Ansible module
+
+    :type login: str
+    :param login: a Linux User or a Linux group if it begins with %
+
+    :type seuser: str
+    :param proto: An SELinux user ('__default__', 'unconfined_u', 'staff_u', ...), see 'semanage login -l'
+
+    :type do_reload: bool
+    :param do_reload: Whether to reload SELinux policy after commit
+
+    :type sestore: str
+    :param sestore: SELinux store
+
+    :rtype: bool
+    :return: True if the policy was changed, otherwise False
+    """
+    try:
+        selogin = seobject.loginRecords(sestore)
+        selogin.set_reload(do_reload)
+        change = False
+        all_logins = selogin.get_all()
+        # module.fail_json(msg="%s: %s %s" % (all_logins, login, sestore))
+        if login in all_logins.keys():
+            change = True
+            if not module.check_mode:
+                selogin.delete(login)
+
+    except (ValueError, KeyError, OSError, RuntimeError) as e:
+        module.fail_json(
+            msg="%s: %s\n" % (e.__class__.__name__, to_native(e)),
+            exception=traceback.format_exc(),
+        )
+
+    return change
+
+
+def get_runtime_status(ignore_selinux_state=False):
+    return True if ignore_selinux_state is True else selinux.is_selinux_enabled()
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            ignore_selinux_state=dict(type="bool", default=False),
+            login=dict(type="str", required=True),
+            seuser=dict(type="str"),
+            selevel=dict(type="str", aliases=["serange"], default="s0"),
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            reload=dict(type="bool", default=True),
+        ),
+        required_if=[["state", "present", ["seuser"]]],
+        supports_check_mode=True,
+    )
+    if not HAVE_SELINUX:
+        module.fail_json(
+            msg=missing_required_lib("libselinux"), exception=SELINUX_IMP_ERR
+        )
+
+    if not HAVE_SEOBJECT:
+        module.fail_json(
+            msg=missing_required_lib("seobject from policycoreutils"),
+            exception=SEOBJECT_IMP_ERR,
+        )
+
+    ignore_selinux_state = module.params["ignore_selinux_state"]
+
+    if not get_runtime_status(ignore_selinux_state):
+        module.fail_json(msg="SELinux is disabled on this host.")
+
+    login = module.params["login"]
+    seuser = module.params["seuser"]
+    serange = module.params["selevel"]
+    state = module.params["state"]
+    do_reload = module.params["reload"]
+
+    result = {
+        "login": login,
+        "seuser": seuser,
+        "serange": serange,
+        "state": state,
+    }
+
+    if state == "present":
+        result["changed"] = semanage_login_add(
+            module, login, seuser, do_reload, serange
+        )
+    elif state == "absent":
+        result["changed"] = semanage_login_del(module, login, seuser, do_reload)
+    else:
+        module.fail_json(msg='Invalid value of argument "state": {0}'.format(state))
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/library/seport.py
+++ b/library/seport.py
@@ -1,0 +1,322 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2014, Dan Keder <dan.keder@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: seport
+short_description: Manages SELinux network port type definitions
+description:
+    - Manages SELinux network port type definitions.
+options:
+  ports:
+    description:
+      - Ports or port ranges.
+      - Can be a list (since 2.6) or comma separated string.
+    type: list
+    elements: str
+    required: true
+  proto:
+    description:
+      - Protocol for the specified port.
+    type: str
+    required: true
+    choices: [ tcp, udp ]
+  setype:
+    description:
+      - SELinux type for the specified port.
+    type: str
+    required: true
+  state:
+    description:
+      - Desired boolean value.
+    type: str
+    choices: [ absent, present ]
+    default: present
+  reload:
+    description:
+      - Reload SELinux policy after commit.
+    type: bool
+    default: yes
+  ignore_selinux_state:
+    description:
+    - Run independent of selinux runtime state
+    type: bool
+    default: no
+notes:
+   - The changes are persistent across reboots.
+   - Not tested on any debian based system.
+requirements:
+- libselinux-python
+- policycoreutils-python
+author:
+- Dan Keder (@dankeder)
+"""
+
+EXAMPLES = r"""
+- name: Allow Apache to listen on tcp port 8888
+  community.general.seport:
+    ports: 8888
+    proto: tcp
+    setype: http_port_t
+    state: present
+
+- name: Allow sshd to listen on tcp port 8991
+  community.general.seport:
+    ports: 8991
+    proto: tcp
+    setype: ssh_port_t
+    state: present
+
+- name: Allow memcached to listen on tcp ports 10000-10100 and 10112
+  community.general.seport:
+    ports: 10000-10100,10112
+    proto: tcp
+    setype: memcache_port_t
+    state: present
+
+- name: Allow memcached to listen on tcp ports 10000-10100 and 10112
+  community.general.seport:
+    ports:
+      - 10000-10100
+      - 10112
+    proto: tcp
+    setype: memcache_port_t
+    state: present
+"""
+
+import traceback
+
+SELINUX_IMP_ERR = None
+try:
+    import selinux
+
+    HAVE_SELINUX = True
+except ImportError:
+    SELINUX_IMP_ERR = traceback.format_exc()
+    HAVE_SELINUX = False
+
+SEOBJECT_IMP_ERR = None
+try:
+    import seobject
+
+    HAVE_SEOBJECT = True
+except ImportError:
+    SEOBJECT_IMP_ERR = traceback.format_exc()
+    HAVE_SEOBJECT = False
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.common.text.converters import to_native
+
+
+def get_runtime_status(ignore_selinux_state=False):
+    return True if ignore_selinux_state is True else selinux.is_selinux_enabled()
+
+
+def semanage_port_get_ports(seport, setype, proto):
+    """Get the list of ports that have the specified type definition.
+
+    :param community.general.seport: Instance of seobject.portRecords
+
+    :type setype: str
+    :param setype: SELinux type.
+
+    :type proto: str
+    :param proto: Protocol ('tcp' or 'udp')
+
+    :rtype: list
+    :return: List of ports that have the specified SELinux type.
+    """
+    records = seport.get_all_by_type()
+    if (setype, proto) in records:
+        return records[(setype, proto)]
+    else:
+        return []
+
+
+def semanage_port_get_type(seport, port, proto):
+    """Get the SELinux type of the specified port.
+
+    :param community.general.seport: Instance of seobject.portRecords
+
+    :type port: str
+    :param port: Port or port range (example: "8080", "8080-9090")
+
+    :type proto: str
+    :param proto: Protocol ('tcp' or 'udp')
+
+    :rtype: tuple
+    :return: Tuple containing the SELinux type and MLS/MCS level, or None if not found.
+    """
+    if isinstance(port, str):
+        ports = port.split("-", 1)
+        if len(ports) == 1:
+            ports.extend(ports)
+    else:
+        ports = (port, port)
+
+    key = (int(ports[0]), int(ports[1]), proto)
+
+    records = seport.get_all()
+    if key in records:
+        return records[key]
+    else:
+        return None
+
+
+def semanage_port_add(
+    module, ports, proto, setype, do_reload, serange="s0", sestore=""
+):
+    """Add SELinux port type definition to the policy.
+
+    :type module: AnsibleModule
+    :param module: Ansible module
+
+    :type ports: list
+    :param ports: List of ports and port ranges to add (e.g. ["8080", "8080-9090"])
+
+    :type proto: str
+    :param proto: Protocol ('tcp' or 'udp')
+
+    :type setype: str
+    :param setype: SELinux type
+
+    :type do_reload: bool
+    :param do_reload: Whether to reload SELinux policy after commit
+
+    :type serange: str
+    :param serange: SELinux MLS/MCS range (defaults to 's0')
+
+    :type sestore: str
+    :param sestore: SELinux store
+
+    :rtype: bool
+    :return: True if the policy was changed, otherwise False
+    """
+    try:
+        seport = seobject.portRecords(sestore)
+        seport.set_reload(do_reload)
+        change = False
+        ports_by_type = semanage_port_get_ports(seport, setype, proto)
+        for port in ports:
+            if port not in ports_by_type:
+                change = True
+                port_type = semanage_port_get_type(seport, port, proto)
+                if port_type is None and not module.check_mode:
+                    seport.add(port, proto, serange, setype)
+                elif port_type is not None and not module.check_mode:
+                    seport.modify(port, proto, serange, setype)
+
+    except (ValueError, IOError, KeyError, OSError, RuntimeError) as e:
+        module.fail_json(
+            msg="%s: %s\n" % (e.__class__.__name__, to_native(e)),
+            exception=traceback.format_exc(),
+        )
+
+    return change
+
+
+def semanage_port_del(module, ports, proto, setype, do_reload, sestore=""):
+    """Delete SELinux port type definition from the policy.
+
+    :type module: AnsibleModule
+    :param module: Ansible module
+
+    :type ports: list
+    :param ports: List of ports and port ranges to delete (e.g. ["8080", "8080-9090"])
+
+    :type proto: str
+    :param proto: Protocol ('tcp' or 'udp')
+
+    :type setype: str
+    :param setype: SELinux type.
+
+    :type do_reload: bool
+    :param do_reload: Whether to reload SELinux policy after commit
+
+    :type sestore: str
+    :param sestore: SELinux store
+
+    :rtype: bool
+    :return: True if the policy was changed, otherwise False
+    """
+    try:
+        seport = seobject.portRecords(sestore)
+        seport.set_reload(do_reload)
+        change = False
+        ports_by_type = semanage_port_get_ports(seport, setype, proto)
+        for port in ports:
+            if port in ports_by_type:
+                change = True
+                if not module.check_mode:
+                    seport.delete(port, proto)
+
+    except (ValueError, IOError, KeyError, OSError, RuntimeError) as e:
+        module.fail_json(
+            msg="%s: %s\n" % (e.__class__.__name__, to_native(e)),
+            exception=traceback.format_exc(),
+        )
+
+    return change
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            ignore_selinux_state=dict(type="bool", default=False),
+            ports=dict(type="list", elements="str", required=True),
+            proto=dict(type="str", required=True, choices=["tcp", "udp"]),
+            setype=dict(type="str", required=True),
+            state=dict(type="str", default="present", choices=["absent", "present"]),
+            reload=dict(type="bool", default=True),
+        ),
+        supports_check_mode=True,
+    )
+
+    if not HAVE_SELINUX:
+        module.fail_json(
+            msg=missing_required_lib("libselinux-python"), exception=SELINUX_IMP_ERR
+        )
+
+    if not HAVE_SEOBJECT:
+        module.fail_json(
+            msg=missing_required_lib("policycoreutils-python"),
+            exception=SEOBJECT_IMP_ERR,
+        )
+
+    ignore_selinux_state = module.params["ignore_selinux_state"]
+
+    if not get_runtime_status(ignore_selinux_state):
+        module.fail_json(msg="SELinux is disabled on this host.")
+
+    ports = module.params["ports"]
+    proto = module.params["proto"]
+    setype = module.params["setype"]
+    state = module.params["state"]
+    do_reload = module.params["reload"]
+
+    result = {
+        "ports": ports,
+        "proto": proto,
+        "setype": setype,
+        "state": state,
+    }
+
+    if state == "present":
+        result["changed"] = semanage_port_add(module, ports, proto, setype, do_reload)
+    elif state == "absent":
+        result["changed"] = semanage_port_del(module, ports, proto, setype, do_reload)
+    else:
+        module.fail_json(msg='Invalid value of argument "state": {0}'.format(state))
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Background: RHEL will support only ansible-core in the future,
in which these selinux modules are not included.

Note: sefcontext.py, selogin.py and seport.py are copied from
community.general to library and black is applied.
