### PR TITLE
Fix version comparisons for ansible_distribution_major_version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
       - policycoreutils-python-utils
     state: present
   when: ansible_distribution == "Fedora" or
-    ( ansible_distribution_major_version > "7" and
+    ( ansible_distribution_major_version | int > 7 and
       ansible_distribution in ["CentOS", "RedHat", "Rocky"] )
 
 - name: Set permanent SELinux state if enabled

--- a/tests/tests_selinux_modules.yml
+++ b/tests/tests_selinux_modules.yml
@@ -22,7 +22,7 @@
           include_role:
             name: linux-system-roles.selinux
       when: ansible_distribution == "Fedora" or
-        ( ansible_distribution_major_version >= "7" and
+        ( ansible_distribution_major_version | int >= 7 and
           ansible_distribution in ["CentOS", "RedHat", "Rocky"] )
       rescue:
         - name: Cleanup modules
@@ -60,7 +60,7 @@
           assert:
             that: test_module_c == 'absent'
       when: ansible_distribution == "Fedora" or
-        ( ansible_distribution_major_version >= "7" and
+        ( ansible_distribution_major_version | int >= 7 and
           ansible_distribution in ["CentOS", "RedHat", "Rocky"] )
       always:
         - name: Cleanup modules
@@ -87,7 +87,7 @@
         - name: execute the role
           include_role:
             name: linux-system-roles.selinux
-      when: ansible_distribution_major_version < "7" and
+      when: ansible_distribution_major_version | int < 7 and
         ansible_distribution in ["CentOS", "RedHat"]
       rescue:
         - name: Cleanup modules
@@ -124,7 +124,7 @@
         - name: Check if linux-system-roles-selinux-test-c is absent
           assert:
             that: test_module_c == 'absent'
-      when: ansible_distribution_major_version < "7" and
+      when: ansible_distribution_major_version | int < 7 and
         ansible_distribution in ["CentOS", "RedHat"]
       always:
         - name: Cleanup modules


### PR DESCRIPTION
Comparisons like `ansible_distribution_major_version > "7"` were broken.
Comparing number strings of different length may result in an unexpected result.
For example `"10" > "7"` evaluates to `false`.
    
Comparisons like `ansible_distribution_major_version | int > 7` were fine.
    
`... is version('7', '>')` could also be used to compare versions.
As the `... | int` conversion is used in many other places, use it for consistency.