### PR TITLE
Add meta/requirements.yml; support ansible-core 2.11

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,5 @@
 ---
 skip_list:
-- '106'
+- '106'  # role name does not match pattern
+- '502'  # All tasks should be named
+- '701'  # ignore meta/requirements.yml

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,0 +1,3 @@
+collections:
+  - name: ansible.posix
+  - name: community.general


### PR DESCRIPTION
The selinux role requires ansible.posix.{selinux,seboolean} and
community.general.{seport,sefcontext,selogin}. Add requirements
for the ansible.posix and community.general collections.

Updated .ansible-lint to support meta/requirements.yml.