### PR TITLE
support gather_facts: false; support setup-snapshot.yml (#71)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,32 +1,6 @@
 ---
-- name: Install SELinux python2 tools
-  package:
-    name:
-      - libselinux-python
-      - policycoreutils-python
-    state: present
-  when: "ansible_python_version is version('3', '<')"
-
-- name: Install SELinux python3 tools
-  package:
-    name:
-      - libselinux-python3
-      - policycoreutils-python3
-    state: present
-  when: "ansible_python_version is version('3', '>=')"
-
-- name: refresh facts
-  setup:
-    filter: ansible_selinux
-
-- name: Install SELinux tool semanage
-  package:
-    name:
-      - policycoreutils-python-utils
-    state: present
-  when: ansible_distribution == "Fedora" or
-    ( ansible_distribution_major_version | int > 7 and
-      ansible_distribution in ["CentOS", "RedHat", "Rocky"] )
+- name: Set ansible_facts required by role and install packages
+  include_tasks: set_facts_packages.yml
 
 - name: Set permanent SELinux state if enabled
   selinux:
@@ -43,7 +17,7 @@
   register: selinux_mod_output_disabled
   when: ansible_selinux.status == "disabled" and selinux_state
 
-- name: Set ansible facts if needed
+- name: Set selinux_reboot_required
   set_fact:
     selinux_reboot_required: "{{ selinux_mod_output_enabled.reboot_required
   if ( selinux_mod_output_enabled.reboot_required is defined ) else (

--- a/tasks/set_facts_packages.yml
+++ b/tasks/set_facts_packages.yml
@@ -1,0 +1,36 @@
+---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__selinux_required_facts) == __selinux_required_facts
+
+- name: Install SELinux python2 tools
+  package:
+    name:
+      - libselinux-python
+      - policycoreutils-python
+    state: present
+  when: "ansible_python_version is version('3', '<')"
+
+- name: Install SELinux python3 tools
+  package:
+    name:
+      - libselinux-python3
+      - policycoreutils-python3
+    state: present
+  when: "ansible_python_version is version('3', '>=')"
+
+- name: refresh facts
+  setup:
+    filter: ansible_selinux
+  when: not __selinux_setup_snapshot | d(false)
+
+- name: Install SELinux tool semanage
+  package:
+    name:
+      - policycoreutils-python-utils
+    state: present
+  when: ansible_distribution == "Fedora" or
+    ( ansible_distribution_major_version | int > 7 and
+      ansible_distribution in ["CentOS", "RedHat", "Rocky"] )

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,8 @@
+- hosts: all
+  tasks:
+    - name: Set ansible_facts and install packages
+      vars:
+        __selinux_setup_snapshot: true
+      include_role:
+        name: linux-system-roles.selinux
+        tasks_from: set_facts_packages.yml

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,5 +1,5 @@
 - name: Ensure that the role runs with default parameters
   hosts: all
-
+  gather_facts: false
   roles:
     - linux-system-roles.selinux

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,3 +4,9 @@ drop_local_modifications: |
   login -D -N
   port -D -N
   fcontext -D -N
+
+# ansible_facts required by the role
+__selinux_required_facts:
+  - distribution
+  - distribution_major_version
+  - python_version


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.
