### PR TITLE
do not use 'become' in tests, examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ vars:
   [ see below ]
 roles:
   - role: linux-system-roles.selinux
-    become: true
 ```
 
 #### purge local modifications

--- a/examples/selinux-playbook.yml
+++ b/examples/selinux-playbook.yml
@@ -1,9 +1,6 @@
 ---
 - name: Manage SELinux policy example
   hosts: all
-  become: true
-  become_method: sudo
-  become_user: root
   vars:
     # Use "targeted" SELinux policy type
     selinux_policy: targeted

--- a/tests/tests_all_purge.yml
+++ b/tests/tests_all_purge.yml
@@ -1,7 +1,6 @@
 ---
 - name: Test that selinux_all_purge drops local modifications, defaults to no
   hosts: all
-  become: true
   gather_facts: true
   vars:
     semanage_change: |

--- a/tests/tests_all_transitions.yml
+++ b/tests/tests_all_transitions.yml
@@ -1,7 +1,6 @@
 ---
 - name: Test all the possible selinux_state transitions
   hosts: all
-  become: true
   tags:
     - tests::reboot
   vars:

--- a/tests/tests_boolean.yml
+++ b/tests/tests_boolean.yml
@@ -1,8 +1,6 @@
 ---
 - name: Check if selinux role sets SELinux booleans
   hosts: all
-  become: true
-
   tasks:
     - name: Initial changes
       include_role:

--- a/tests/tests_fcontext.yml
+++ b/tests/tests_fcontext.yml
@@ -1,7 +1,6 @@
 ---
 - name: Check if selinux role sets SELinux fcontext mappings
   hosts: all
-  become: true
   vars:
     __str1: >-
       /tmp/test_dir1[^ ]+[ ]+directory[

--- a/tests/tests_login.yml
+++ b/tests/tests_login.yml
@@ -1,8 +1,6 @@
 ---
 - name: Check if selinux role sets SELinux login mappings
   hosts: all
-  become: true
-
   tasks:
     - name: Add a System Api Roles SELinux User
       user:

--- a/tests/tests_port.yml
+++ b/tests/tests_port.yml
@@ -1,8 +1,6 @@
 ---
 - name: Check if selinux role sets SELinux port mapping
   hosts: all
-  become: true
-
   tasks:
     - name: Initial changes
       include_role:

--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -1,7 +1,6 @@
 ---
 - name: Ensure the default is targeted, enforcing, without local modifications
   hosts: all
-  become: true
   gather_facts: true
   vars:
     selinux_all_purge: true

--- a/tests/tests_selinux_modules.yml
+++ b/tests/tests_selinux_modules.yml
@@ -1,7 +1,6 @@
 ---
 - name: Test management of SELinux modules
   hosts: all
-  become: true
   tasks:
     - name: Execute the role and catch errors
       vars:

--- a/tests/tests_selinux_modules_checksum.yml
+++ b/tests/tests_selinux_modules_checksum.yml
@@ -1,7 +1,6 @@
 ---
 - name: Test management of SELinux modules
   hosts: all
-  become: true
   tasks:
     - name: Execute the role and catch errors
       when: ansible_distribution == "Fedora" or


### PR DESCRIPTION
The main reason is that the baseos ci test runner does not have `sudo`
installed by default, so we would need to use a different `become`
method.
But since we have to modify all of these anyway, best to just get
rid of `become`.  In general, you can't really use this role without
being root on the managed node, so it is implied.  Ansible recommends
to let the user specify `become` if necessary.  There are a variety
of ways the user can specify become:

* ansible-playbook CLI `--become` et. al.

https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html

* connection variables

https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html#connection-variables

* environment variables, configuration settings

https://docs.ansible.com/ansible/latest/reference_appendices/config.html
