### PR TITLE
Use lookup file + sha256 to get hash of local policy file

### DIFF
--- a/tasks/selinux_load_module.yml
+++ b/tasks/selinux_load_module.yml
@@ -1,18 +1,19 @@
 ---
+# NOTE: The use of `file` lookup is in order to
+# find and load files on the control node without using
+# modules and `local_action` or `delegate_to` which will
+# attempt to connect, become, etc. which the user may not
+# desire to do.
 - name: Prepare module installation
-  when: state == "enabled" and item.path is defined
+  when:
+    - state == "enabled"
+    - item.path is defined
   block:
-    - name: Get checksum for {{ item.path }}
-      stat:
-        path: "{{ item.path }}"
-        checksum_algorithm: sha256
-      register: module_file
-      delegate_to: localhost
-
     - name: Install module
-      when:
-        not module_file.stat.checksum in checksum
-
+      vars:
+        __chksum: "{{ lookup('file', item.path, rstrip=false) |
+          hash('sha256') }}"
+      when: not __chksum in checksum
       block:
         - name: Create temporary directory
           tempfile:


### PR DESCRIPTION
This is a follow up to https://github.com/linux-system-roles/selinux/issues/142
The `delegate_to: localhost`, if using `become` with the playbook, is causing
a `sudo` to `localhost`.  Use a `file` lookup through a `hash` filter to
get the checksum instead and try to bypass that delegation.
