### PR TITLE
ansible-lint - use changed_when for conditional tasks

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
   command: semodule -R
   listen: __selinux_reload_policy
   when: ansible_selinux.status != "disabled"
+  changed_when: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,22 +41,27 @@
     stdin: "{{ drop_local_modifications }}"
   when: selinux_all_purge | bool
   notify: __selinux_reload_policy
+  changed_when: true
 
 - name: Purge all SELinux boolean local modifications
   command: /usr/sbin/semanage boolean -D
   when: selinux_booleans_purge | bool
+  changed_when: true
 
 - name: Purge all SELinux file context local modifications
   command: /usr/sbin/semanage fcontext -D
   when: selinux_fcontexts_purge | bool
+  changed_when: true
 
 - name: Purge all SELinux port local modifications
   command: /usr/sbin/semanage port -D
   when: selinux_ports_purge | bool
+  changed_when: true
 
 - name: Purge all SELinux login local modifications
   command: /usr/sbin/semanage login -D
   when: selinux_logins_purge | bool
+  changed_when: true
 
 - name: Set SELinux booleans
   # noqa fqcn[action]


### PR DESCRIPTION
ansible-lint now requires the use of changed_when even for
conditional tasks

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
