### PR TITLE
test: ensure the test works with ANSIBLE_GATHERING=explicit

### DIFF
--- a/tests/set_selinux_variables.yml
+++ b/tests/set_selinux_variables.yml
@@ -1,33 +1,59 @@
 ---
-- name: Ensure SELinux tool semanage
-  package:
-    name:
-      - policycoreutils-python-utils
-    state: present
-  when: ansible_distribution == "Fedora" or
-    (ansible_distribution_major_version | int > 7 and
-     ansible_distribution in ["CentOS", "RedHat", "Rocky"])
-- name: Ensure SELinux tool semanage on EL7
-  package:
-    name:
-      - policycoreutils-python
-    state: present
-  when:
-    - ansible_distribution_major_version | int == 7
-    - ansible_os_family == "RedHat"
-- name: Get local modifications - boolean
-  command: /usr/sbin/semanage boolean -l -n -C
-  changed_when: false
-  register: selinux_role_boolean
-- name: Get local modifications - port
-  command: /usr/sbin/semanage port -l -n -C
-  changed_when: false
-  register: selinux_role_port
-- name: Get local modifications - login
-  command: /usr/sbin/semanage login -l -n -C
-  changed_when: false
-  register: selinux_role_login
-- name: Get local modifications - fcontext
-  command: /usr/sbin/semanage fcontext -l -n -C
-  changed_when: false
-  register: selinux_role_fcontext
+- name: Ensure facts, test variables used by role
+  vars:
+    __selinux_test_facts:
+      - distribution
+      - distribution_major_version
+      - os_family
+    __selinux_test_facts_regex: "{{ '^(' ~
+      (__selinux_test_facts | join('|')) ~ ')$' }}"
+  block:
+    - name: Ensure ansible_facts used by tests
+      setup:
+        gather_subset: min
+      when: not ansible_facts.keys() | list |
+        intersect(__selinux_test_facts) == __selinux_test_facts
+
+    - name: Ensure SELinux tool semanage
+      package:
+        name:
+          - policycoreutils-python-utils
+        state: present
+      when: ansible_distribution == "Fedora" or
+        (ansible_distribution_major_version | int > 7 and
+        ansible_distribution in ["CentOS", "RedHat", "Rocky"])
+
+    - name: Ensure SELinux tool semanage on EL7
+      package:
+        name:
+          - policycoreutils-python
+        state: present
+      when:
+        - ansible_distribution_major_version | int == 7
+        - ansible_os_family == "RedHat"
+
+    - name: Get local modifications - boolean
+      command: /usr/sbin/semanage boolean -l -n -C
+      changed_when: false
+      register: selinux_role_boolean
+
+    - name: Get local modifications - port
+      command: /usr/sbin/semanage port -l -n -C
+      changed_when: false
+      register: selinux_role_port
+
+    - name: Get local modifications - login
+      command: /usr/sbin/semanage login -l -n -C
+      changed_when: false
+      register: selinux_role_login
+
+    - name: Get local modifications - fcontext
+      command: /usr/sbin/semanage fcontext -l -n -C
+      changed_when: false
+      register: selinux_role_fcontext
+  always:
+    - name: Unset facts used above
+      set_fact:
+        ansible_facts: "{{ ansible_facts | dict2items |
+          rejectattr('key', 'match', __selinux_test_facts_regex) |
+          list | items2dict }}"

--- a/tests/tests_selinux_modules.yml
+++ b/tests/tests_selinux_modules.yml
@@ -2,6 +2,16 @@
 - name: Test management of SELinux modules
   hosts: all
   tasks:
+    - name: Ensure facts, test variables used by role
+      set_fact:
+        __selinux_test_facts:
+          - distribution
+          - distribution_major_version
+    - name: Ensure ansible_facts used by test
+      setup:
+        gather_subset: min
+      when: not ansible_facts.keys() | list |
+        intersect(__selinux_test_facts) == __selinux_test_facts
     - name: Execute the role and catch errors
       vars:
         selinux_modules:
@@ -19,6 +29,14 @@
         (ansible_distribution_major_version | int >= 7 and
          ansible_distribution in ["CentOS", "RedHat", "Rocky"])
       block:
+        - name: Unset test facts
+          set_fact:
+            ansible_facts: "{{ ansible_facts | dict2items |
+              rejectattr('key', 'match', __selinux_test_facts_regex) |
+              list | items2dict }}"
+          vars:
+            __selinux_test_facts_regex: "{{ '^(' ~
+              (__selinux_test_facts | join('|')) ~ ')$' }}"
         - name: Execute the role
           include_role:
             name: linux-system-roles.selinux

--- a/tests/tests_selinux_modules_checksum.yml
+++ b/tests/tests_selinux_modules_checksum.yml
@@ -2,6 +2,16 @@
 - name: Test management of SELinux modules
   hosts: all
   tasks:
+    - name: Ensure facts, test variables used by role
+      set_fact:
+        __selinux_test_facts:
+          - distribution
+          - distribution_version
+    - name: Ensure ansible_facts used by test
+      setup:
+        gather_subset: min
+      when: not ansible_facts.keys() | list |
+        intersect(__selinux_test_facts) == __selinux_test_facts
     - name: Execute the role and catch errors
       when: ansible_distribution == "Fedora" or
         (ansible_distribution in ["CentOS", "RedHat", "Rocky"] and
@@ -10,6 +20,14 @@
         selinux_modules:
           - {path: "selinux_modules/linux-system-roles-selinux-test-a.pp"}
       block:
+        - name: Unset test facts
+          set_fact:
+            ansible_facts: "{{ ansible_facts | dict2items |
+              rejectattr('key', 'match', __selinux_test_facts_regex) |
+              list | items2dict }}"
+          vars:
+            __selinux_test_facts_regex: "{{ '^(' ~
+              (__selinux_test_facts | join('|')) ~ ')$' }}"
         - name: Execute the role
           include_role:
             name: linux-system-roles.selinux


### PR DESCRIPTION
Ensure the tests have the facts they need when testing with
`ANSIBLE_GATHERING=explicit`, but remove them before running the
role to ensure the role will ensure the facts it needs.
