### PR TITLE
feat: Use `restorecon -T 0` on Fedora and RHEL > 8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,13 +82,13 @@
   with_items: "{{ selinux_fcontexts }}"
 
 - name: Restore SELinux labels on filesystem tree
-  command: /sbin/restorecon -R -F -v {{ item }}
+  command: /sbin/restorecon -R -F -v {{ restorecon_threads }} {{ item }}
   with_items: "{{ selinux_restore_dirs }}"
   register: restorecon_cmd
   changed_when: '"Relabeled" in restorecon_cmd.stdout'
 
 - name: Restore SELinux labels on filesystem tree in check mode
-  command: /sbin/restorecon -R -F -v -n {{ item }}
+  command: /sbin/restorecon -R -F -v -n {{ restorecon_threads }} {{ item }}
   with_items: "{{ selinux_restore_dirs }}"
   register: restorecon_cmd
   changed_when: '"Would relabel" in restorecon_cmd.stdout'

--- a/tests/tests_restore_dirs.yml
+++ b/tests/tests_restore_dirs.yml
@@ -1,0 +1,54 @@
+---
+- name: Check if selinux role restores directory SELinux context
+  hosts: all
+  tasks:
+    - name: Create tempdir, set fcontext and relabel
+      block:
+        - name: Create temporary directory
+          tempfile:
+            state: directory
+            prefix: linux_system_role.selinux
+          register: tempdir
+
+        - name: Create temporary file
+          tempfile:
+            path: "{{ tempdir.path }}"
+            state: file
+            suffix: temp
+          register: tempfile
+
+        - name: Set default_t context to {{ tempdir.path }}
+          command: chcon -R -t default_t {{ tempdir.path }}
+          changed_when: true
+
+        - name: Run the role
+          include_role:
+            name: linux-system-roles.selinux
+          vars:
+            selinux_fcontexts:
+              - {target: "{{ tempdir.path }}(/.*)?", setype: "user_tmp_t"}
+            selinux_restore_dirs:
+              - "{{ tempdir.path }}"
+
+        - name: Get SELinux context of {{ tempfile.path }}
+          command: ls -Z {{ tempfile.path }}
+          register: tempfile_ls
+          changed_when: false
+
+        - name: Check whether SELinux label on {{ tempfile.path }}
+          assert:
+            that: >
+              "system_u:object_r:user_tmp_t:s0" in tempfile_ls.stdout
+
+      always:
+        - name: Clean temporary directory {{ tempdir.path }}
+          file:
+            path: "{{ tempdir.path }}"
+            state: absent
+        - name: Clean temporary fcontext
+          include_role:
+            name: linux-system-roles.selinux
+          vars:
+            selinux_fcontexts:
+              - {target: "{{ tempdir.path }}(/.*)?", setype: "user_tmp_t",
+                 state: "absent"}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,3 +10,7 @@ __selinux_required_facts:
   - distribution
   - distribution_major_version
   - python_version
+
+restorecon_threads: "{{ '-T 0' if ansible_distribution == 'Fedora' or
+  (ansible_distribution_major_version | int > 8 and
+  ansible_distribution in ['CentOS', 'RedHat', 'Rocky']) else '' }}"


### PR DESCRIPTION
From restorecon(8):

       -T nthreads
              use up to nthreads threads.  Specify 0 to create as many
              threads as there are available CPU cores; 1 to use only a
              single thread  (default); or any positive number to use
              the given number of threads (if possible).