### PR TITLE
ci: fix python 2.7 CI tests by manually installing python2.7 package

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -42,7 +42,14 @@ jobs:
       - name: checkout PR
         uses: actions/checkout@v3
 
-      - name: Set up Python
+      - name: Set up Python 2.7
+        if: ${{ matrix.pyver_os.ver == '2.7' }}
+        run: |
+          set -euxo pipefail
+          sudo apt install -y python2.7
+
+      - name: Set up Python 3
+        if: ${{ matrix.pyver_os.ver != '2.7' }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pyver_os.ver }}


### PR DESCRIPTION
We use the setup-python github action.  This has dropped support for
python 2.7.  Instead, just manually install the python2.7 package.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
