### PR TITLE
refactor: ansible-lint - vars cannot be reserved names

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -120,10 +120,11 @@
 - name: Load SELinux modules
   include_tasks: selinux_load_module.yml
   vars:
-    name: "{{ item.name | default(item.path | basename | splitext | first) }}"
+    mod_name: "{{ item.name |
+      default(item.path | default('') | basename | splitext | first) }}"
     state: "{{ item.state | default('enabled') }}"
     priority: "{{ item.priority | default('400') }}"
     # yamllint disable rule:line-length
-    checksum: "{{ selinux_installed_modules[name][priority]['checksum'] | default('sha256:') }}"
+    checksum: "{{ selinux_installed_modules[mod_name][priority]['checksum'] | default('sha256:') }}"
   when: selinux_modules is defined
   loop: "{{ selinux_modules | flatten(levels=1) }}"

--- a/tasks/selinux_load_module.yml
+++ b/tasks/selinux_load_module.yml
@@ -55,7 +55,7 @@
 
 - name: Remove module
   local_semodule:
-    name: "{{ item.name }}"
+    name: "{{ mod_name }}"
     state: absent
     priority: "{{ priority }}"
   when: state == "absent"
@@ -63,14 +63,14 @@
 
 - name: Enable module
   local_semodule:
-    name: "{{ item.name }}"
+    name: "{{ mod_name }}"
     state: enabled
   when: state == "enabled" and item.path is not defined
   notify: __selinux_reload_policy
 
 - name: Disable module
   local_semodule:
-    name: "{{ item.name }}"
+    name: "{{ mod_name }}"
     state: "disabled"
   when: state == "disabled" and item.path is not defined
   notify: __selinux_reload_policy


### PR DESCRIPTION
https://ansible.readthedocs.io/projects/lint/rules/var-naming/
`var-naming[no-reserved]: Variables names must not be Ansible reserved names`

Fixes this error:

```
var-naming[no-reserved]: Variables names must not be Ansible reserved names. (name)
tasks/main.yml:123
```

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
