### PR TITLE
fix: facts being gathered unnecessarily

### DIFF
--- a/tasks/set_facts_packages.yml
+++ b/tasks/set_facts_packages.yml
@@ -1,9 +1,9 @@
 ---
 - name: Ensure ansible_facts used by role
   setup:
-    gather_subset: min
-  when: not ansible_facts.keys() | list |
-    intersect(__selinux_required_facts) == __selinux_required_facts
+    gather_subset: "{{ __selinux_required_facts_subsets }}"
+  when: __selinux_required_facts |
+    difference(ansible_facts.keys() | list) | length > 0
 
 - name: Install SELinux python2 tools
   package:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,6 +11,12 @@ __selinux_required_facts:
   - distribution_major_version
   - python_version
 
+# the subsets of ansible_facts that need to be gathered in case any of the
+# facts in required_facts is missing; see the documentation of
+# the 'gather_subset' parameter of the 'setup' module
+__selinux_required_facts_subsets: "{{ ['!all', '!min'] +
+  __selinux_required_facts }}"
+
 restorecon_threads: "{{ '-T 0' if ansible_distribution == 'Fedora' or
   (ansible_distribution_major_version | int > 8 and
   ansible_distribution in ['CentOS', 'RedHat', 'Rocky']) else '' }}"


### PR DESCRIPTION
Cause: The comparison of the present facts with the required facts is
being done on unsorted lists.

Consequence: The comparison may fail if the only difference is the
order.  Facts are gathered unnecessarily.

Fix: Use `difference` which works no matter what the order is.  Ensure
that the fact gathering subsets used are the absolute minimum required.

Result: The role gathers only the facts it requires, and does
not unnecessarily gather facts.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
