### PR TITLE
Fix #188

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -103,6 +103,7 @@
     state: "{{ item.state | default('present') }}"
     local: "{{ item.local | default(False) }}"
   with_items: "{{ selinux_ports }}"
+  when: selinux_state != "disabled"
 
 - name: Set linux user to SELinux user mapping
   selogin:


### PR DESCRIPTION
Set an SELinux label on a port only when selinux_state is not disabled

Enhancement: Fix #188

Reason: Avoid bloating inventory for hosts that have `selinux_state=disabled`

Result: ?

Issue Tracker Tickets (Jira or BZ if any): https://github.com/linux-system-roles/selinux/issues/188
