### PR TITLE
refactor: use primary package names instead of aliases

### DIFF
--- a/tasks/set_facts_packages.yml
+++ b/tasks/set_facts_packages.yml
@@ -16,8 +16,8 @@
 - name: Install SELinux python3 tools
   package:
     name:
-      - libselinux-python3
-      - policycoreutils-python3
+      - python3-libselinux
+      - python3-policycoreutils
     state: present
   when: ansible_python_version is version('3', '>=')
 


### PR DESCRIPTION
The package names `python3-libselinux` and `python3-policycoreutils`
are the actual package names.  The others are aliases - they
are `Provides:` in the RPM.  Using the actual package names makes
it easier for ostree integration as well.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
