### PR TITLE
fix: make role work again on Suse - not officially supported

### DIFF
--- a/tasks/set_facts_packages.yml
+++ b/tasks/set_facts_packages.yml
@@ -19,7 +19,19 @@
       - python3-libselinux
       - python3-policycoreutils
     state: present
-  when: ansible_python_version is version('3', '>=')
+  when:
+    - ansible_python_version is version('3', '>=')
+    - ansible_os_family == "RedHat"
+
+- name: Install SELinux python3 tools
+  package:
+    name:
+      - python3-selinux
+      - python3-policycoreutils
+    state: present
+  when:
+    - ansible_python_version is version('3', '>=')
+    - ansible_os_family == "Suse"
 
 - name: Refresh facts
   setup:


### PR DESCRIPTION
Note that Suse is unofficially supported.  The recent change for
the python3 library names made the role break on Suse.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
