### PR TITLE
feat: support for ostree systems

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -23,5 +23,6 @@ exclude_paths:
 mock_modules:
   - sefcontext
   - selogin
+  - ansible.utils.update_fact
 mock_roles:
   - linux-system-roles.selinux

--- a/.ostree/README.md
+++ b/.ostree/README.md
@@ -1,0 +1,3 @@
+*NOTE*: The `*.txt` files are used by `get_ostree_data.sh` to create the lists
+of packages, and to find other system roles used by this role.  DO NOT use them
+directly.

--- a/.ostree/get_ostree_data.sh
+++ b/.ostree/get_ostree_data.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+set -euo pipefail
+
+role_collection_dir="${ROLE_COLLECTION_DIR:-fedora/linux_system_roles}"
+ostree_dir="${OSTREE_DIR:-"$(dirname "$(realpath "$0")")"}"
+
+if [ -z "${4:-}" ] || [ "${1:-}" = help ] || [ "${1:-}" = -h ]; then
+    cat <<EOF
+Usage: $0 packages [runtime|testing] DISTRO-MAJOR[.MINOR] [json|yaml|raw|toml]
+The script will use the packages and roles files in $ostree_dir to
+construct the list of packages needed to build the ostree image.  The script
+will output the list of packages in the given format
+- json is a JSON list like ["pkg1","pkg2",....,"pkgN"]
+- yaml is the YAML list format
+- raw is the list of packages, one per line
+- toml is a list of [[packages]] elements as in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index#creating-an-image-builder-blueprint-for-a-rhel-for-edge-image-using-the-command-line-interface_composing-a-rhel-for-edge-image-using-image-builder-command-line
+The DISTRO-MAJOR.MINOR is the same format used by Ansible for distribution e.g. CentOS-8, RedHat-8.9, etc.
+EOF
+    exit 1
+fi
+category="$1"
+pkgtype="$2"
+distro_ver="$3"
+format="$4"
+pkgtypes=("$pkgtype")
+if [ "$pkgtype" = testing ]; then
+    pkgtypes+=(runtime)
+fi
+
+get_rolepath() {
+    local ostree_dir role rolesdir
+    ostree_dir="$1"
+    role="$2"
+    rolesdir="$(dirname "$(dirname "$ostree_dir")")/$role/.ostree"
+    if [ -d "$rolesdir" ]; then
+        echo "$rolesdir"
+        return 0
+    fi
+    if [ -n "${ANSIBLE_COLLECTIONS_PATHS:-}" ]; then
+        for pth in ${ANSIBLE_COLLECTIONS_PATHS//:/ }; do
+            rolesdir="$pth/ansible_collections/$role_collection_dir/roles/$role/.ostree"
+            if [ -d "$rolesdir" ]; then
+                echo "$rolesdir"
+                return 0
+            fi
+        done
+    fi
+    return 1
+}
+
+get_packages() {
+    local ostree_dir pkgtype pkgfile rolefile
+    ostree_dir="$1"
+    for pkgtype in "${pkgtypes[@]}"; do
+        for suff in "" "-$distro" "-${distro}-${major_ver}" "-${distro}-${ver}"; do
+            pkgfile="$ostree_dir/packages-${pkgtype}${suff}.txt"
+            if [ -f "$pkgfile" ]; then
+                cat "$pkgfile"
+            fi
+        done
+        rolefile="$ostree_dir/roles-${pkgtype}.txt"
+        if [ -f "$rolefile" ]; then
+            local roles role rolepath
+            roles="$(cat "$rolefile")"
+            for role in $roles; do
+                rolepath="$(get_rolepath "$ostree_dir" "$role")"
+                get_packages "$rolepath"
+            done
+        fi
+    done | sort -u
+}
+
+format_packages_json() {
+    local comma pkgs pkg
+    comma=""
+    pkgs="["
+    while read -r pkg; do
+        pkgs="${pkgs}${comma}\"${pkg}\""
+        comma=,
+    done
+    pkgs="${pkgs}]"
+    echo "$pkgs"
+}
+
+format_packages_raw() {
+    cat
+}
+
+format_packages_yaml() {
+    while read -r pkg; do
+        echo "- $pkg"
+    done
+}
+
+format_packages_toml() {
+    while read -r pkg; do
+        echo "[[packages]]"
+        echo "name = \"$pkg\""
+        echo "version = \"*\""
+    done
+}
+
+distro="${distro_ver%%-*}"
+ver="${distro_ver##*-}"
+if [[ "$ver" =~ ^([0-9]*) ]]; then
+    major_ver="${BASH_REMATCH[1]}"
+else
+    echo ERROR: cannot parse major version number from version "$ver"
+    exit 1
+fi
+
+"get_$category" "$ostree_dir" | "format_${category}_$format"

--- a/.ostree/packages-runtime-CentOS-7.txt
+++ b/.ostree/packages-runtime-CentOS-7.txt
@@ -1,0 +1,2 @@
+libselinux-python
+policycoreutils-python

--- a/.ostree/packages-runtime-CentOS-8.txt
+++ b/.ostree/packages-runtime-CentOS-8.txt
@@ -1,0 +1,3 @@
+policycoreutils-python-utils
+python3-libselinux
+python3-policycoreutils

--- a/.ostree/packages-runtime-CentOS-9.txt
+++ b/.ostree/packages-runtime-CentOS-9.txt
@@ -1,0 +1,3 @@
+policycoreutils-python-utils
+python3-libselinux
+python3-policycoreutils

--- a/.ostree/packages-runtime-Fedora.txt
+++ b/.ostree/packages-runtime-Fedora.txt
@@ -1,0 +1,3 @@
+policycoreutils-python-utils
+python3-libselinux
+python3-policycoreutils

--- a/.ostree/packages-runtime-RedHat-6.txt
+++ b/.ostree/packages-runtime-RedHat-6.txt
@@ -1,0 +1,2 @@
+libselinux-python
+policycoreutils-python

--- a/.ostree/packages-runtime-RedHat-7.txt
+++ b/.ostree/packages-runtime-RedHat-7.txt
@@ -1,0 +1,2 @@
+libselinux-python
+policycoreutils-python

--- a/.ostree/packages-runtime-RedHat-8.txt
+++ b/.ostree/packages-runtime-RedHat-8.txt
@@ -1,0 +1,3 @@
+policycoreutils-python-utils
+python3-libselinux
+python3-policycoreutils

--- a/.ostree/packages-runtime-RedHat-9.txt
+++ b/.ostree/packages-runtime-RedHat-9.txt
@@ -1,0 +1,3 @@
+policycoreutils-python-utils
+python3-libselinux
+python3-policycoreutils

--- a/.ostree/packages-testing-CentOS-7.txt
+++ b/.ostree/packages-testing-CentOS-7.txt
@@ -1,0 +1,2 @@
+policycoreutils-python
+util-linux

--- a/.ostree/packages-testing-CentOS-8.txt
+++ b/.ostree/packages-testing-CentOS-8.txt
@@ -1,0 +1,2 @@
+policycoreutils-python-utils
+util-linux

--- a/.ostree/packages-testing-CentOS-9.txt
+++ b/.ostree/packages-testing-CentOS-9.txt
@@ -1,0 +1,2 @@
+policycoreutils-python-utils
+util-linux-core

--- a/.ostree/packages-testing-Fedora.txt
+++ b/.ostree/packages-testing-Fedora.txt
@@ -1,0 +1,2 @@
+policycoreutils-python-utils
+util-linux-core

--- a/.ostree/packages-testing-RedHat-7.txt
+++ b/.ostree/packages-testing-RedHat-7.txt
@@ -1,0 +1,2 @@
+policycoreutils-python
+util-linux

--- a/.ostree/packages-testing-RedHat-8.txt
+++ b/.ostree/packages-testing-RedHat-8.txt
@@ -1,0 +1,2 @@
+policycoreutils-python-utils
+util-linux

--- a/.ostree/packages-testing-RedHat-9.txt
+++ b/.ostree/packages-testing-RedHat-9.txt
@@ -1,0 +1,2 @@
+policycoreutils-python-utils
+util-linux-core

--- a/.ostree/packages-testing.txt
+++ b/.ostree/packages-testing.txt
@@ -1,0 +1,1 @@
+selinux-policy-targeted

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -1,0 +1,1 @@
+roles/selinux/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -1,0 +1,1 @@
+roles/selinux/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -1,0 +1,1 @@
+roles/selinux/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -1,0 +1,1 @@
+roles/selinux/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -1,0 +1,1 @@
+roles/selinux/.ostree/get_ostree_data.sh shebang!skip

--- a/README-ostree.md
+++ b/README-ostree.md
@@ -1,0 +1,66 @@
+# rpm-ostree
+
+The role supports running on [rpm-ostree](https://coreos.github.io/rpm-ostree/)
+systems. The primary issue is that the `/usr` filesystem is read-only, and the
+role cannot install packages. Instead, it will just verify that the necessary
+packages and any other `/usr` files are pre-installed. The role will change the
+package manager to one that is compatible with `rpm-ostree` systems.
+
+## Building
+
+To build an ostree image for a particular operating system distribution and
+version, use the script `.ostree/get_ostree_data.sh` to get the list of
+packages. If the role uses other system roles, then the script will include the
+packages for the other roles in the list it outputs.  The list of packages will
+be sorted in alphanumeric order.
+
+Usage:
+
+```bash
+.ostree/get_ostree_data.sh packages runtime DISTRO-VERSION FORMAT
+```
+
+`DISTRO-VERSION` is in the format that Ansible uses for `ansible_distribution`
+and `ansible_distribution_version` - for example, `Fedora-38`, `CentOS-8`,
+`RedHat-9.4`
+
+`FORMAT` is one of `toml`, `json`, `yaml`, `raw`
+
+* `toml` - each package in a TOML `[[packages]]` element
+
+```toml
+[[packages]]
+name = "package-a"
+version = "*"
+[[packages]]
+name = "package-b"
+version = "*"
+...
+```
+
+* `yaml` - a YAML list of packages
+
+```yaml
+- package-a
+- package-b
+...
+```
+
+* `json` - a JSON list of packages
+
+```json
+["package-a","package-b",...]
+```
+
+* `raw` - a plain text list of packages, one per line
+
+```bash
+package-a
+package-b
+...
+```
+
+What format you choose depends on which image builder you are using.  For
+example, if you are using something based on
+[osbuild-composer](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index#creating-an-image-builder-blueprint-for-a-rhel-for-edge-image-using-the-command-line-interface_composing-a-rhel-for-edge-image-using-image-builder-command-line),
+you will probably want to use the `toml` output format.

--- a/README.md
+++ b/README.md
@@ -17,18 +17,16 @@ Essentially provide mechanisms to manage local customizations:
 
 ## Requirements
 
+See below
+
 ### Collection requirements
 
-The role requires some SELinux modules.  If you are using `ansible-core`, you
-must get these from the `ansible.posix` and `community.general` collections.
-Use the file `meta/collection-requirements.yml` to install these:
+The role requires external collections.  Use the following command to install
+them:
 
 ```bash
 ansible-galaxy collection install -vv -r meta/collection-requirements.yml
 ```
-
-If you are using Ansible Engine 2.9, or are using an Ansible bundle which
-includes these collections/modules, you should have to do nothing.
 
 ## Modules provided by this repository
 
@@ -231,3 +229,7 @@ on Red Hat Enterprise Linux 6
 
 The general usage is demonstrated in
 [selinux-playbook.yml](examples/selinux-playbook.yml) playbook.
+
+## rpm-ostree
+
+See README-ostree.md

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,4 +1,5 @@
 ---
 collections:
   - name: ansible.posix
+  - name: ansible.utils
   - name: community.general

--- a/tasks/ensure_selinux_packages.yml
+++ b/tasks/ensure_selinux_packages.yml
@@ -1,0 +1,60 @@
+---
+- name: Ensure correct package manager for ostree systems
+  vars:
+    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
+    ostree_booted_file: /run/ostree-booted
+  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: "{{ ostree_booted_file }}"
+      register: __ostree_booted_stat
+
+    - name: Set package manager to use for ostree
+      ansible.utils.update_fact:
+        updates:
+          - path: ansible_facts.pkg_mgr
+            value: "{{ ostree_pkg_mgr }}"
+      when: __ostree_booted_stat.stat.exists
+
+- name: Install SELinux python2 tools
+  package:
+    name:
+      - libselinux-python
+      - policycoreutils-python
+    state: present
+  when: ansible_python_version is version('3', '<')
+
+- name: Install SELinux python3 tools
+  package:
+    name:
+      - python3-libselinux
+      - python3-policycoreutils
+    state: present
+  when:
+    - ansible_python_version is version('3', '>=')
+    - ansible_os_family == "RedHat"
+
+- name: Install SELinux python3 tools
+  package:
+    name:
+      - python3-selinux
+      - python3-policycoreutils
+    state: present
+  when:
+    - ansible_python_version is version('3', '>=')
+    - ansible_os_family == "Suse"
+
+- name: Install SELinux tool semanage
+  package:
+    name:
+      - policycoreutils-python-utils
+    state: present
+  when: ansible_distribution == "Fedora" or
+    (ansible_distribution_major_version | int > 7 and
+     ansible_distribution in ["CentOS", "RedHat", "Rocky"])
+
+- name: Refresh facts
+  setup:
+    filter: ansible_selinux
+  when: not __selinux_setup_snapshot | d(false)

--- a/tasks/set_facts_packages.yml
+++ b/tasks/set_facts_packages.yml
@@ -5,44 +5,5 @@
   when: __selinux_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
-- name: Install SELinux python2 tools
-  package:
-    name:
-      - libselinux-python
-      - policycoreutils-python
-    state: present
-  when: ansible_python_version is version('3', '<')
-
-- name: Install SELinux python3 tools
-  package:
-    name:
-      - python3-libselinux
-      - python3-policycoreutils
-    state: present
-  when:
-    - ansible_python_version is version('3', '>=')
-    - ansible_os_family == "RedHat"
-
-- name: Install SELinux python3 tools
-  package:
-    name:
-      - python3-selinux
-      - python3-policycoreutils
-    state: present
-  when:
-    - ansible_python_version is version('3', '>=')
-    - ansible_os_family == "Suse"
-
-- name: Refresh facts
-  setup:
-    filter: ansible_selinux
-  when: not __selinux_setup_snapshot | d(false)
-
-- name: Install SELinux tool semanage
-  package:
-    name:
-      - policycoreutils-python-utils
-    state: present
-  when: ansible_distribution == "Fedora" or
-    (ansible_distribution_major_version | int > 7 and
-     ansible_distribution in ["CentOS", "RedHat", "Rocky"])
+- name: Ensure SELinux packages
+  include_tasks: ensure_selinux_packages.yml

--- a/tests/set_selinux_variables.yml
+++ b/tests/set_selinux_variables.yml
@@ -14,43 +14,51 @@
       when: not ansible_facts.keys() | list |
         intersect(__selinux_test_facts) == __selinux_test_facts
 
-    - name: Ensure SELinux tool semanage
+    - name: Ensure SELinux testing packages
+      include_role:
+        name: linux-system-roles.selinux
+        tasks_from: ensure_selinux_packages.yml
+
+    - name: Ensure selinux-policy-targeted
       package:
-        name:
-          - policycoreutils-python-utils
+        name: selinux-policy-targeted
         state: present
-      when: ansible_distribution == "Fedora" or
-        (ansible_distribution_major_version | int > 7 and
-        ansible_distribution in ["CentOS", "RedHat", "Rocky"])
+      when: __selinux_need_policy_targeted | d(false)
 
-    - name: Ensure SELinux tool semanage on EL7
+    - name: Ensure findmnt
       package:
-        name:
-          - policycoreutils-python
+        name: "{{ findmnt_pkg }}"
         state: present
-      when:
-        - ansible_distribution_major_version | int == 7
-        - ansible_os_family == "RedHat"
+      when: __selinux_need_findmnt | d(false)
+      vars:
+        findmnt_pkg: "{{ 'util-linux-core'
+          if (ansible_facts['os_family'] == 'RedHat' and
+              ansible_facts['distribution_major_version'] is version('8', '>'))
+          else 'util-linux' if ansible_facts['os_family'] == 'RedHat'
+          else 'util-linux' }}"
 
-    - name: Get local modifications - boolean
-      command: /usr/sbin/semanage boolean -l -n -C
-      changed_when: false
-      register: selinux_role_boolean
+    - name: Get test facts
+      when: __selinux_get_test_facts | d(true)
+      block:
+        - name: Get local modifications - boolean
+          command: /usr/sbin/semanage boolean -l -n -C
+          changed_when: false
+          register: selinux_role_boolean
 
-    - name: Get local modifications - port
-      command: /usr/sbin/semanage port -l -n -C
-      changed_when: false
-      register: selinux_role_port
+        - name: Get local modifications - port
+          command: /usr/sbin/semanage port -l -n -C
+          changed_when: false
+          register: selinux_role_port
 
-    - name: Get local modifications - login
-      command: /usr/sbin/semanage login -l -n -C
-      changed_when: false
-      register: selinux_role_login
+        - name: Get local modifications - login
+          command: /usr/sbin/semanage login -l -n -C
+          changed_when: false
+          register: selinux_role_login
 
-    - name: Get local modifications - fcontext
-      command: /usr/sbin/semanage fcontext -l -n -C
-      changed_when: false
-      register: selinux_role_fcontext
+        - name: Get local modifications - fcontext
+          command: /usr/sbin/semanage fcontext -l -n -C
+          changed_when: false
+          register: selinux_role_fcontext
   always:
     - name: Unset facts used above
       set_fact:

--- a/tests/tests_all_purge.yml
+++ b/tests/tests_all_purge.yml
@@ -10,23 +10,11 @@
       login -a -s staff_u sar-user
 
   tasks:
-    - name: Ensure SELinux tool semanage
-      package:
-        name:
-          - policycoreutils-python-utils
-        state: present
-      when: ansible_distribution == "Fedora" or
-        (ansible_distribution_major_version | int > 7 and
-         ansible_distribution in ["CentOS", "RedHat", "Rocky"])
-
-    - name: Ensure SELinux tool semanage on EL7
-      package:
-        name:
-          - policycoreutils-python
-        state: present
-      when:
-        - ansible_distribution_major_version | int == 7
-        - ansible_os_family == "RedHat"
+    - name: Ensure SELinux test packages
+      include_tasks:
+        file: set_selinux_variables.yml
+      vars:
+        __selinux_get_test_facts: false
 
     - name: Add a Linux System Roles SELinux User
       user:

--- a/tests/tests_all_transitions.yml
+++ b/tests/tests_all_transitions.yml
@@ -10,6 +10,19 @@
       - disabled
 
   tasks:
+    - name: Check if test is supported
+      vars:
+        ostree_booted_file: /run/ostree-booted
+      block:
+        - name: Check if system is ostree
+          stat:
+            path: "{{ ostree_booted_file }}"
+          register: __ostree_booted_stat
+
+        - name: Skip if not supported
+          meta: end_host
+          when: __ostree_booted_stat.stat.exists
+
     - name: Save config
       include_tasks: selinux_config_save.yml
 

--- a/tests/tests_modifications_with_selinux_disabled.yml
+++ b/tests/tests_modifications_with_selinux_disabled.yml
@@ -7,11 +7,13 @@
     selinux_logins_purge: true
 
   tasks:
-    - name: Ensure selinux-policy-targeted
-      package:
-        name:
-          - selinux-policy-targeted
-        state: present
+    - name: Ensure SELinux test packages
+      include_tasks:
+        file: set_selinux_variables.yml
+      vars:
+        __selinux_get_test_facts: false
+        __selinux_need_policy_targeted: true
+        __selinux_need_findmnt: true
 
     - name: Add a Linux System Roles SELinux User
       user:

--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -13,23 +13,12 @@
       login -a -s staff_u sar-user
 
   tasks:
-    - name: Ensure SELinux tool semanage
-      package:
-        name:
-          - policycoreutils-python-utils
-        state: present
-      when: ansible_distribution == "Fedora" or
-        (ansible_distribution_major_version | int > 7 and
-         ansible_distribution in ["CentOS", "RedHat", "Rocky"])
-
-    - name: Ensure SELinux tool semanage on EL7
-      package:
-        name:
-          - policycoreutils-python
-        state: present
-      when:
-        - ansible_distribution_major_version | int == 7
-        - ansible_os_family == "RedHat"
+    - name: Ensure SELinux test packages
+      include_tasks:
+        file: set_selinux_variables.yml
+      vars:
+        __selinux_get_test_facts: false
+        __selinux_need_findmnt: true
 
     - name: Add a Linux System Roles SELinux User
       user:

--- a/tests/tests_selinux_modules.yml
+++ b/tests/tests_selinux_modules.yml
@@ -29,14 +29,6 @@
         (ansible_distribution_major_version | int >= 7 and
          ansible_distribution in ["CentOS", "RedHat", "Rocky"])
       block:
-        - name: Unset test facts
-          set_fact:
-            ansible_facts: "{{ ansible_facts | dict2items |
-              rejectattr('key', 'match', __selinux_test_facts_regex) |
-              list | items2dict }}"
-          vars:
-            __selinux_test_facts_regex: "{{ '^(' ~
-              (__selinux_test_facts | join('|')) ~ ')$' }}"
         - name: Execute the role
           include_role:
             name: linux-system-roles.selinux

--- a/tests/tests_selinux_modules_checksum.yml
+++ b/tests/tests_selinux_modules_checksum.yml
@@ -20,20 +20,18 @@
         selinux_modules:
           - {path: "selinux_modules/linux-system-roles-selinux-test-a.pp"}
       block:
-        - name: Unset test facts
-          set_fact:
-            ansible_facts: "{{ ansible_facts | dict2items |
-              rejectattr('key', 'match', __selinux_test_facts_regex) |
-              list | items2dict }}"
-          vars:
-            __selinux_test_facts_regex: "{{ '^(' ~
-              (__selinux_test_facts | join('|')) ~ ')$' }}"
         - name: Execute the role
           include_role:
             name: linux-system-roles.selinux
           register: role_result
+        - name: Get commit_num file
+          set_fact:
+            commit_num_file: "{{
+              (ansible_facts.pkg_mgr == 'ansible.posix.rhel_rpm_ostree') |
+              ternary('/etc/selinux/targeted/active/commit_num',
+                      '/var/lib/selinux/targeted/active/commit_num') }}"
         - name: Get current commit_num
-          command: cat /var/lib/selinux/targeted/active/commit_num
+          command: cat {{ commit_num_file | quote }}
           register: commit_num_before
           changed_when: false
         - name: Execute the role
@@ -41,7 +39,7 @@
             name: linux-system-roles.selinux
           register: role_result
         - name: Get current commit_num
-          command: cat /var/lib/selinux/targeted/active/commit_num
+          command: cat {{ commit_num_file | quote }}
           register: commit_num_after
           changed_when: false
         - name: Check commit numbers


### PR DESCRIPTION
Feature: Allow running and testing the role with ostree managed nodes.

Reason: We have users who want to use the role to manage ostree
systems.

Result: Users can use the role to manage ostree managed nodes.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
