### PR TITLE
fix: Print an error message when module to be created doesn't exist

### DIFF
--- a/tasks/selinux_load_module.yml
+++ b/tasks/selinux_load_module.yml
@@ -26,6 +26,13 @@
       delegate_to: localhost
       become: false
 
+    - name: Raise an error when module file doesn't exist
+      fail:
+        msg: >-
+          The module that you try to install does not exist in
+          {{ __selinux_item.path }}
+      when: not module_file.stat.exists
+
     - name: Install module
       when: not module_file.stat.checksum in checksum
       block:


### PR DESCRIPTION
Enhancement: Print an error message when module to be created doesn't exist

Reason: When specifying a non-existent file with `selinux_modules.path` the role fails with an informative message that the module file that you try to install doesn't exist.