### PR TITLE
ci: support ansible-lint and ansible-test 2.16

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -21,7 +21,7 @@ exclude_paths:
   - .markdownlint.yaml
   - examples/roles/
 mock_modules:
-  - sefcontext
-  - selogin
+  - community.general.sefcontext
+  - community.general.selogin
 mock_roles:
   - linux-system-roles.selinux

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+---
 # Default state for all rules
 default: true
 

--- a/library/local_semodule.py
+++ b/library/local_semodule.py
@@ -42,6 +42,7 @@ options:
     description:
       - Use other than current SELinux module store, e.g. mls, minimum, refpolicy ...
     type: str
+    default: ""
 notes:
    - The changes are persistent across reboots.
    - Not tested on any debian based system.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,7 +76,7 @@
     loop_var: __selinux_item
 
 - name: Set SELinux file contexts
-  sefcontext:
+  community.general.sefcontext:
     target: "{{ __selinux_item.target }}"
     setype: "{{ __selinux_item.setype }}"
     ftype: "{{ __selinux_item.ftype | default('a') }}"
@@ -101,7 +101,7 @@
     loop_var: __selinux_item
 
 - name: Set linux user to SELinux user mapping
-  selogin:
+  community.general.selogin:
     login: "{{ __selinux_item.login }}"
     seuser: "{{ __selinux_item.seuser }}"
     serange: "{{ __selinux_item.serange | default('s0') }}"


### PR DESCRIPTION
Fix yamllint issue with markdownlint config

Use FQCN for community.general modules

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
