### PR TITLE
test: Add python_version to test facts gather ansible_python_version

### DIFF
--- a/tests/set_selinux_variables.yml
+++ b/tests/set_selinux_variables.yml
@@ -5,6 +5,7 @@
       - distribution
       - distribution_major_version
       - os_family
+      - python_version
     __selinux_test_facts_regex: "{{ '^(' ~
       (__selinux_test_facts | join('|')) ~ ')$' }}"
     __selinux_test_facts_subsets: "{{ ['!all', '!min'] +

--- a/tests/tests_fcontext.yml
+++ b/tests/tests_fcontext.yml
@@ -1,6 +1,7 @@
 ---
 - name: Check if selinux role sets SELinux fcontext mappings
   hosts: all
+  gather_facts: false
   vars:
     __str1: >-
       /tmp/test_dir1[^ ]+[ ]+directory[


### PR DESCRIPTION
Enhancement: Add python_version to test required_facts to gather ansible_python_version fact

Reason: The role didn't gather ansible_python_version but used it in tests_fcontext.yml

Result: The bug is fixed