### PR TITLE
ci: bump ansible-lint to v25; provide collection requirements for ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -21,8 +21,6 @@ exclude_paths:
   - .markdownlint.yaml
   - examples/roles/
 mock_modules:
-  - community.general.sefcontext
-  - community.general.selogin
   - seboolean
   - selinux
 mock_roles:

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -35,6 +35,7 @@ jobs:
           pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
+        id: collection
         run: |
           set -euxo pipefail
           TOXENV=collection lsr_ci_runtox
@@ -42,8 +43,38 @@ jobs:
           # ansible-lint action requires a .git directory???
           # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
           mkdir -p "$coll_dir/.git"
+          meta_req_file="${{ github.workspace }}/meta/collection-requirements.yml"
+          test_req_file="${{ github.workspace }}/tests/collection-requirements.yml"
+          if [ -f "$meta_req_file" ] && [ -f "$test_req_file" ]; then
+            coll_req_file="${{ github.workspace }}/req.yml"
+            python -c 'import sys; import yaml
+          hsh1 = yaml.safe_load(open(sys.argv[1]))
+          hsh2 = yaml.safe_load(open(sys.argv[2]))
+          coll = {}
+          for item in hsh1["collections"] + hsh2["collections"]:
+            if isinstance(item, dict):
+              name = item["name"]
+              rec = item
+            else:
+              name = item  # assume string
+              rec = {"name": name}
+            if name not in coll:
+              coll[name] = rec
+          hsh1["collections"] = list(coll.values())
+          yaml.safe_dump(hsh1, open(sys.argv[3], "w"))' "$meta_req_file" "$test_req_file" "$coll_req_file"
+            echo merged "$coll_req_file"
+            cat "$coll_req_file"
+          elif [ -f "$meta_req_file" ]; then
+            coll_req_file="$meta_req_file"
+          elif [ -f "$test_req_file" ]; then
+            coll_req_file="$test_req_file"
+          else
+            coll_req_file=""
+          fi
+          echo "coll_req_file=$coll_req_file" >> $GITHUB_OUTPUT
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v24
+        uses: ansible/ansible-lint@v25
         with:
           working_directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
+          requirements_file: ${{ steps.collection.outputs.coll_req_file }}

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -43,7 +43,8 @@ jobs:
           # cleanup
           rm -rf "$coll_dir/.ansible"
           # check
-          tail .ansible/collections/ansible_collections/community/general/plugins/modules/ini_file.py || :
+          ls -alrtF .ansible/collections/ansible_collections/community/general/plugins/modules/sefcontext.py || :
+          tail .ansible/collections/ansible_collections/community/general/plugins/modules/sefcontext.py || :
           # ansible-lint action requires a .git directory???
           # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
           mkdir -p "$coll_dir/.git"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -41,10 +41,11 @@ jobs:
           TOXENV=collection lsr_ci_runtox
           coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
           # cleanup
+          ls -alrtF "$coll_dir/.ansible" || :
           rm -rf "$coll_dir/.ansible"
           # check
-          ls -alrtF .ansible/collections/ansible_collections/community/general/plugins/modules/sefcontext.py || :
-          tail .ansible/collections/ansible_collections/community/general/plugins/modules/sefcontext.py || :
+          pwd
+          find -name sefcontext.py -ls
           # ansible-lint action requires a .git directory???
           # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
           mkdir -p "$coll_dir/.git"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -41,7 +41,7 @@ jobs:
           TOXENV=collection lsr_ci_runtox
           coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
           # cleanup
-          rm -rf .tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"/.ansible
+          rm -rf "$coll_dir/.ansible"
           # check
           tail .ansible/collections/ansible_collections/community/general/plugins/modules/ini_file.py || :
           # ansible-lint action requires a .git directory???

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -40,6 +40,10 @@ jobs:
           set -euxo pipefail
           TOXENV=collection lsr_ci_runtox
           coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+          # cleanup
+          rm -rf .tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"/.ansible
+          # check
+          tail .ansible/collections/ansible_collections/community/general/plugins/modules/ini_file.py || :
           # ansible-lint action requires a .git directory???
           # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
           mkdir -p "$coll_dir/.git"


### PR DESCRIPTION
There is a new version of ansible-lint - v25.
Newer versions of ansible-lint require the collection requirements to be
installed so it can find the modules/plugins.
Enhance our ansible-lint ci job to provide the collection requirements,
including merging the runtime meta/collection-requirements.yml with
the testing tests/collection-requirements.yml.
This should somewhat mitigate the loss of ansible-plugin-scan.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
