### PR TITLE
fix: Set the kernel command line selinux parameter correctly when changing selinux state

### DIFF
--- a/.ostree/packages-runtime-CentOS-10.txt
+++ b/.ostree/packages-runtime-CentOS-10.txt
@@ -1,3 +1,4 @@
+grubby
 policycoreutils-python-utils
 python3-libselinux
 python3-policycoreutils

--- a/.ostree/packages-runtime-CentOS-8.txt
+++ b/.ostree/packages-runtime-CentOS-8.txt
@@ -1,3 +1,4 @@
+grubby
 policycoreutils-python-utils
 python3-libselinux
 python3-policycoreutils

--- a/.ostree/packages-runtime-CentOS-9.txt
+++ b/.ostree/packages-runtime-CentOS-9.txt
@@ -1,3 +1,4 @@
+grubby
 policycoreutils-python-utils
 python3-libselinux
 python3-policycoreutils

--- a/.ostree/packages-runtime-RedHat-10.txt
+++ b/.ostree/packages-runtime-RedHat-10.txt
@@ -1,3 +1,4 @@
+grubby
 policycoreutils-python-utils
 python3-libselinux
 python3-policycoreutils

--- a/.ostree/packages-runtime-RedHat-8.txt
+++ b/.ostree/packages-runtime-RedHat-8.txt
@@ -1,3 +1,4 @@
+grubby
 policycoreutils-python-utils
 python3-libselinux
 python3-policycoreutils

--- a/.ostree/packages-runtime-RedHat-9.txt
+++ b/.ostree/packages-runtime-RedHat-9.txt
@@ -1,3 +1,4 @@
+grubby
 policycoreutils-python-utils
 python3-libselinux
 python3-policycoreutils

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ This uses the
 [selinux](https://docs.ansible.com/ansible/latest/collections/ansible/posix/selinux_module.html#ansible-collections-ansible-posix-selinux-module)
 module to manage the SELinux mode and policy.
 
+**NOTE:** On EL 8 and later, the role will use the `update_kernel_param: true` of
+the `selinux` module to update the kernel command line in order to ensure the
+selinux state update is applied and persistent upon reboot.
+
 ### selinux_booleans
 
 Manage the state of SELinux booleans.  This is a `list` of `dict`, where each

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,3 +2,4 @@
 collections:
   - name: ansible.posix
   - name: community.general
+  - name: fedora.linux_system_roles

--- a/tasks/ensure_selinux_packages.yml
+++ b/tasks/ensure_selinux_packages.yml
@@ -58,6 +58,16 @@
     - ansible_os_family == "Suse"
   register: selinux_python3_tools_result
 
+- name: Ensure grubby used to modify selinux kernel parameter
+  package:
+    name: grubby
+    state: present
+    use: "{{ (__selinux_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+  when:
+    - ansible_facts["os_family"] == "RedHat"
+    - ansible_facts["distribution_major_version"] is version("8", ">=")
+
 - name: Install SELinux tool semanage
   package:
     name:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,33 +2,60 @@
 - name: Set ansible_facts required by role and install packages
   include_tasks: set_facts_packages.yml
 
-- name: Set permanent SELinux state if enabled
-  # noqa args[module] fqcn[action]
-  selinux:
-    state: "{{ selinux_state | default(ansible_selinux.config_mode, true) }}"
-    policy: "{{ selinux_policy | default(ansible_selinux.type, true) }}"
-  register: selinux_mod_output_enabled
-  when: ansible_selinux.status == "enabled" and
-        (selinux_state or selinux_policy)
+- name: Set permanent SELinux state
+  vars:
+    __update_kernel_param: "{{ ansible_facts['os_family'] == 'RedHat' and
+      ansible_facts['distribution_major_version'] is version('8', '>=') and
+      ansible_version.full is version('2.10', '>=') }}"
+  block:
+    - name: Set permanent SELinux state if enabled
+      # noqa args[module] fqcn[action]
+      selinux:
+        state: "{{ selinux_state | default(ansible_selinux.config_mode, true) }}"
+        policy: "{{ selinux_policy | default(ansible_selinux.type, true) }}"
+        update_kernel_param: "{{ true if __update_kernel_param else omit }}"
+      register: selinux_mod_output_enabled
+      when:
+        - ansible_selinux.status == "enabled"
+        - selinux_state or selinux_policy
 
-- name: Set permanent SELinux state if disabled
-  # noqa args[module] fqcn[action]
-  selinux:
-    state: "{{ selinux_state }}"
-    policy: "{{ selinux_policy | default('targeted', true) }}"
-  register: selinux_mod_output_disabled
-  when: ansible_selinux.status == "disabled" and selinux_state
+    - name: Set permanent SELinux state if disabled
+      # noqa args[module] fqcn[action]
+      selinux:
+        state: "{{ selinux_state }}"
+        policy: "{{ selinux_policy | default('targeted', true) }}"
+        update_kernel_param: "{{ true if __update_kernel_param else omit }}"
+      register: selinux_mod_output_disabled
+      when:
+        - ansible_selinux.status == "disabled"
+        - selinux_state | d(none)
 
-- name: Set selinux_reboot_required
-  set_fact:
-    selinux_reboot_required: "{{ selinux_mod_output_enabled.reboot_required
-      if (selinux_mod_output_enabled.reboot_required is defined) else
-      (selinux_mod_output_disabled.reboot_required | default(false)) }}"
+    - name: Set selinux_reboot_required
+      set_fact:
+        selinux_reboot_required: "{{ selinux_mod_output_enabled.reboot_required
+          if (selinux_mod_output_enabled.reboot_required is defined) else
+          (selinux_mod_output_disabled.reboot_required | default(false)) }}"
 
-- name: Fail if reboot is required
-  fail:
-    msg: "Reboot is required to apply changes. Re-execute the role after boot."
-  when: selinux_reboot_required
+    - name: Add or remove selinux=0 from args as needed
+      when:
+        - not __update_kernel_param
+        - selinux_reboot_required | bool
+      include_role:
+        name: fedora.linux_system_roles.bootloader
+      vars:
+        bootloader_settings:
+          - kernel: ALL
+            options:
+              - name: selinux
+                value: "0"
+                state: "{{ 'present'
+                  if selinux_mod_output_enabled.reboot_required | default(false)
+                  else 'absent' }}"
+
+    - name: Fail if reboot is required
+      fail:
+        msg: "Reboot is required to apply changes. Re-execute the role after boot."
+      when: selinux_reboot_required
 
 - name: Warn if SELinux is disabled
   debug:

--- a/tests/selinux_config_restore.yml
+++ b/tests/selinux_config_restore.yml
@@ -14,15 +14,8 @@
 
 - name: Reboot
   when: restorecon is changed  # noqa no-handler
-  block:
-    - name: Restart managed host
-      shell: sleep 2 && shutdown -r now "Ansible updates triggered"
-      async: 1
-      poll: 0
-      ignore_errors: true  # noqa ignore-errors
-      changed_when: false
-
-    - name: Wait for managed host to come back
-      wait_for_connection:
-        delay: 10
-        timeout: 300
+  reboot:
+    msg: Ansible updates triggered
+    pre_reboot_delay: 2
+    post_reboot_delay: 10
+    reboot_timeout: 300

--- a/tests/set_selinux_variables.yml
+++ b/tests/set_selinux_variables.yml
@@ -72,9 +72,3 @@
           command: /usr/sbin/semanage fcontext -l -n -C
           changed_when: false
           register: selinux_role_fcontext
-  always:
-    - name: Unset facts used above
-      set_fact:
-        ansible_facts: "{{ ansible_facts | dict2items |
-          rejectattr('key', 'match', __selinux_test_facts_regex) |
-          list | items2dict }}"

--- a/tests/tests_all_transitions.yml
+++ b/tests/tests_all_transitions.yml
@@ -23,8 +23,54 @@
           meta: end_host
           when: __ostree_booted_stat.stat.exists
 
+    - name: Include test variables
+      import_tasks: set_selinux_variables.yml
+
     - name: Save config
       include_tasks: selinux_config_save.yml
+
+    - name: Get selinux facts
+      setup:
+        filter: ansible_selinux
+
+    - name: Save selinux state before test
+      set_fact:
+        __state_before: "{{ ansible_selinux.mode | d(ansible_selinux.status) }}"
+        __type_before: "{{ ansible_selinux.type }}"
+
+    - name: See if we can use update_kernel_param
+      set_fact:
+        __test_update_kernel_param: "{{ ansible_facts['os_family'] == 'RedHat' and
+          ansible_facts['distribution_major_version'] is version('8', '>=') and
+          ansible_version.full is version('2.10', '>=') }}"
+
+    - name: Disable selinux and set kernel
+      ansible.posix.selinux:
+        state: disabled
+        update_kernel_param: "{{ true if __test_update_kernel_param else omit }}"
+      register: __disable_result
+
+    - name: Add selinux=0 to kernel args
+      when:
+        - not __test_update_kernel_param
+        - __disable_result.reboot_required
+      include_role:
+        name: fedora.linux_system_roles.bootloader
+      vars:
+        bootloader_settings:
+          - kernel: ALL
+            options:
+              - name: selinux
+                value: "0"
+                state: present
+
+    - name: Show __disable_result
+      debug:
+        msg: __disable_result is {{ __disable_result | to_nice_json }}
+
+    - name: Reboot
+      reboot:
+      when: __disable_result.reboot_required
 
     - name: Test all the possible state transitions
       include_tasks: selinux_test_transitions.yml
@@ -37,3 +83,31 @@
 
     - name: Restore config
       include_tasks: selinux_config_restore.yml
+
+    - name: Re-enable selinux and set kernel if disabled
+      ansible.posix.selinux:
+        state: "{{ __state_before }}"
+        policy: "{{ __type_before }}"
+        update_kernel_param: "{{ true if ansible_facts['os_family'] == 'RedHat' and
+          ansible_facts['distribution_major_version'] is version('8', '>=')
+          else omit }}"
+      register: __enable_result
+      when: __disable_result.reboot_required
+
+    - name: Remove selinux=0 from kernel args
+      when:
+        - not __test_update_kernel_param
+        - __enable_result.reboot_required
+      include_role:
+        name: fedora.linux_system_roles.bootloader
+      vars:
+        bootloader_settings:
+          - kernel: ALL
+            options:
+              - name: selinux
+                value: "0"
+                state: absent
+
+    - name: Reboot
+      reboot:
+      when: __enable_result.reboot_required

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,6 +9,7 @@ drop_local_modifications: |
 __selinux_required_facts:
   - distribution
   - distribution_major_version
+  - os_family
   - python_version
 
 # the subsets of ansible_facts that need to be gathered in case any of the


### PR DESCRIPTION
Cause: On EL8 and later, the role was not setting the kernel selinux parameter when
changing the selinux state to and from disabled.

Consequence: The selinux state change was not persistent upon reboot.

Fix: Ensure that the kernel selinux parameter is correctly set when the role
changes the selinux state to and from disabled.

Result: The selinux state change to and from disabled is persistent upon reboot
on EL8 and later systems.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>