### PR TITLE
docs(changelog): version 1.8.3 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -58,8 +58,9 @@ SOFTWARE.
   </style>
   <style type="text/css">code{white-space: pre;}</style>
   <style type="text/css">
+html { -webkit-text-size-adjust: 100%; }
 pre > code.sourceCode { white-space: pre; position: relative; }
-pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
 .sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
@@ -70,7 +71,7 @@ div.sourceCode { overflow: auto; }
 }
 @media print {
 pre > code.sourceCode { white-space: pre-wrap; }
-pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
 }
 pre.numberSource code
   { counter-reset: source-line 0; }
@@ -239,6 +240,10 @@ enabled, the policy is not changed.</p>
 <p>This uses the <a
 href="https://docs.ansible.com/ansible/latest/collections/ansible/posix/selinux_module.html#ansible-collections-ansible-posix-selinux-module">selinux</a>
 module to manage the SELinux mode and policy.</p>
+<p><strong>NOTE:</strong> On EL 8 and later, the role will use the
+<code>update_kernel_param: true</code> of the <code>selinux</code>
+module to update the kernel command line in order to ensure the selinux
+state update is applied and persistent upon reboot.</p>
 <h2 id="selinux_booleans">selinux_booleans</h2>
 <p>Manage the state of SELinux booleans. This is a <code>list</code> of
 <code>dict</code>, where each <code>dict</code> is in the same format as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 Changelog
 =========
 
+[1.8.3] - 2025-05-30
+--------------------
+
+### Bug Fixes
+
+- fix: Set the kernel command line selinux parameter correctly when changing selinux state (#275)
+
+### Other Changes
+
+- ci: ansible-plugin-scan is disabled for now (#259)
+- ci: bump ansible-lint to v25; provide collection requirements for ansible-lint (#262)
+- ci: Check spelling with codespell (#263)
+- ci: Add test plan that runs CI tests and customize it for each role (#264)
+- ci: In test plans, prefix all relate variables with SR_ (#265)
+- ci: Fix bug with ARTIFACTS_URL after prefixing with SR_ (#266)
+- ci: several changes related to new qemu test, ansible-lint, python versions, ubuntu versions (#267)
+- ci: use tox-lsr 3.6.0; improve qemu test logging (#268)
+- ci: skip storage scsi, nvme tests in github qemu ci (#269)
+- ci: bump sclorg/testing-farm-as-github-action from 3 to 4 (#270)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#272)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#273)
+
 [1.8.2] - 2025-01-09
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.8.3

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare release 1.8.3 with a SELinux persistence bug fix, CI pipeline improvements, and documentation and styling updates

Bug Fixes:
- Set the kernel command line SELinux parameter correctly when changing SELinux state

CI:
- Disable ansible-plugin-scan; bump ansible-lint to v25 and add collection requirements; add codespell; overhaul test plans with SR_ prefixing; fix ARTIFACTS_URL; improve QEMU test logging; skip storage SCSI and NVMe tests; bump sclorg/testing-farm action; bump tox-lsr to 3.9.0 and rename QEMU/KVM tests; add Fedora 42 support and use lsr-report-errors

Documentation:
- Add CSS adjustments for code block rendering and HTML text-size behavior
- Document use of update_kernel_param in SELinux module on EL 8+ to persist state updates