### PR TITLE
feat: Partially support this role in container builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Users may also pass the following optional parameters:
 
 Individual modifications can be dropped by setting `state` to `absent`.
 
+Note: The `selinux_fcontexts` option does not work in container builds.
+
 ### selinux_ports
 
 Manage the state of SELinux port policy.  This is a `list` of `dict`, where each
@@ -201,6 +203,8 @@ supported policydb module version on target systems, i.e. on the oldest system.
 
 **Note:** Managing modules is idempotent only on Fedora, and EL 8.6 and later.
 You can manage modules on older releases, but it will not be idempotent.
+
+Note: The `selinux_modules` option does not work in container builds.
 
 ### selinux_transactional_update_reboot_ok
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
         - "9"
   galaxy_tags:
     - centos
+    - containerbuild
     - el6
     - el7
     - el8

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,26 @@
 - name: Set ansible_facts required by role and install packages
   include_tasks: set_facts_packages.yml
 
+- name: Determine if system is booted with systemd
+  when: __selinux_is_booted is not defined
+  block:
+    - name: Run systemctl
+      # noqa command-instead-of-module
+      command: systemctl is-system-running
+      register: __is_system_running
+      changed_when: false
+      failed_when: false
+
+    - name: Require installed systemd
+      fail:
+        msg: "Error: This role requires systemd to be installed."
+      when: '"No such file or directory" in __is_system_running.msg | d("")'
+
+    - name: Set flag to indicate that systemd runtime operations are available
+      set_fact:
+        # see https://www.man7.org/linux/man-pages/man1/systemctl.1.html#:~:text=is-system-running%20output
+        __selinux_is_booted: "{{ __is_system_running.stdout != 'offline' }}"
+
 - name: Set permanent SELinux state
   vars:
     __update_kernel_param: "{{ ansible_facts['os_family'] == 'RedHat' and
@@ -55,7 +75,9 @@
     - name: Fail if reboot is required
       fail:
         msg: "Reboot is required to apply changes. Re-execute the role after boot."
-      when: selinux_reboot_required
+      when:
+        - selinux_reboot_required
+        - __selinux_is_booted | bool
 
 - name: Warn if SELinux is disabled
   debug:

--- a/tests/tests_modifications_with_selinux_disabled.yml
+++ b/tests/tests_modifications_with_selinux_disabled.yml
@@ -1,6 +1,9 @@
 ---
 - name: Ensure the default is targeted, enforcing, without local modifications
   hosts: all
+  tags:
+    # (un)mounting SELinux fs does not work in container builds
+    - tests::booted
   gather_facts: true
   vars:
     selinux_all_purge: true

--- a/tests/tests_restore_dirs.yml
+++ b/tests/tests_restore_dirs.yml
@@ -1,6 +1,9 @@
 ---
 - name: Check if selinux role restores directory SELinux context
   hosts: all
+  tags:
+    # labelling does not work in container builds
+    - tests::booted
   tasks:
     - name: Create tempdir, set fcontext and relabel
       block:

--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -1,6 +1,9 @@
 ---
 - name: Ensure the default is targeted, enforcing, without local modifications
   hosts: all
+  tags:
+    # (un)mounting SELinux fs does not work in container builds
+    - tests::booted
   gather_facts: true
   vars:
     selinux_all_purge: true

--- a/tests/tests_selinux_modules.yml
+++ b/tests/tests_selinux_modules.yml
@@ -1,6 +1,9 @@
 ---
 - name: Test management of SELinux modules
   hosts: all
+  tags:
+    # but modules do not work in container builds
+    - tests::booted
   tasks:
     - name: Ensure facts, test variables used by role
       set_fact:

--- a/tests/tests_selinux_modules_checksum.yml
+++ b/tests/tests_selinux_modules_checksum.yml
@@ -1,6 +1,9 @@
 ---
 - name: Test management of SELinux modules
   hosts: all
+  tags:
+    # modules do not work in container builds
+    - tests::booted
   tasks:
     - name: Ensure facts, test variables used by role
       set_fact:


### PR DESCRIPTION
Feature: Support running the selinux role during container builds, except for setting contexts and configuring modules.

Reason: This is particularly useful for building bootc derivative OSes.

Result: These flags enable running the bootc container scenarios in CI, which ensures that the role works in buildah build environment. This allows us to officially support this role for image mode builds.

Make the role not fail in container (non-booted) environments if a reboot is required. That will happen implicitly on deployment.

Note that SELinux modules and file labels don't currently work in containers. Skip the corresponding test and add notes to the documentation. But it's still useful to set the enforcing/permissive state, target policy, ports, or booleans.

Fixes https://issues.redhat.com/browse/RHEL-93205

## Summary by Sourcery

Enable partial SELinux role support in container builds by detecting non-booted environments, skipping unsupported operations, and updating documentation, tests, metadata, and CI workflows.

New Features:
- Detect non-booted systemd environments to allow role execution in containers
- Skip module loading and file context labeling operations in container builds

Enhancements:
- Bypass reboot-required failures when running in container contexts
- Add documentation notes for unsupported SELinux options in container builds
- Add ‘containerbuild’ tag to Galaxy metadata

CI:
- Bump tox-lsr dependency to v3.9.1 across CI workflows

Tests:
- Tag reboot, module, and labeling tests to skip in container build scenarios