### PR TITLE
refactor: Ansible 2.19 support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,8 @@
       register: selinux_mod_output_enabled
       when:
         - ansible_selinux.status == "enabled"
-        - selinux_state or selinux_policy
+        - (not selinux_state is none and selinux_state | length > 0) or
+          (not selinux_policy is none and selinux_policy | length > 0)
 
     - name: Set permanent SELinux state if disabled
       # noqa args[module] fqcn[action]
@@ -48,7 +49,8 @@
       register: selinux_mod_output_disabled
       when:
         - ansible_selinux.status == "disabled"
-        - selinux_state | d(none)
+        - not selinux_state is none
+        - selinux_state | length > 0
 
     - name: Set selinux_reboot_required
       set_fact:

--- a/tests/tests_selinux_modules.yml
+++ b/tests/tests_selinux_modules.yml
@@ -62,14 +62,14 @@
           enabled"
           assert:
             that:
-              selinux_installed_modules['linux-system-roles-selinux-test-a']['400']['enabled']
+              selinux_installed_modules['linux-system-roles-selinux-test-a']['400']['enabled'] != 0
 
         - name: "Check if linux-system-roles-selinux-test-b is installed and
           disabled"
           assert:
             that:
               # yamllint disable rule:line-length
-              not selinux_installed_modules['linux-system-roles-selinux-test-b']['500']['enabled']
+              selinux_installed_modules['linux-system-roles-selinux-test-b']['500']['enabled'] == 0
 
         - name: Check if linux-system-roles-selinux-test-c is absent
           assert:
@@ -128,14 +128,14 @@
           enabled"
           assert:
             that:
-              selinux_installed_modules['linux-system-roles-selinux-test-a']['0']['enabled']
+              selinux_installed_modules['linux-system-roles-selinux-test-a']['0']['enabled'] != 0
 
         - name: "Check if linux-system-roles-selinux-test-b is installed
           and disabled"
           assert:
             that:
               # yamllint disable rule:line-length
-              not selinux_installed_modules['linux-system-roles-selinux-test-b']['0']['enabled']
+              selinux_installed_modules['linux-system-roles-selinux-test-b']['0']['enabled'] == 0
 
         - name: Check if linux-system-roles-selinux-test-c is absent
           assert:


### PR DESCRIPTION
Ansible 2.19 introduces some big changes
https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_core_2.19.html

One big change is that data structures are no longer mutable by the use of python
methods such as `__setitem__`, `setdefault`, `update`, etc.  in Jinja constructs.
Instead, items must use filters or other Jinja operations.

One common idiom is to mutate each element in a list.  Since we cannot do this
"in-place" anymore, a common way to do this is:

```yaml
- name: Construct a new list from an existing list and mutate each element
  set_fact:
    __new_list: "{{ __new_list | d([]) + [mutated_item] }}"
  loop: "{{ old_list }}"
  mutated_item: "{{ some value based on item from old list }}"

- name: Reset original old list
  set_fact:
    old_list: "{{ __new_list }}"
```

Similarly with `dict` items:

```yaml
- name: Construct a new dict from an existing dict and mutate each element
  set_fact:
    __new_dict: "{{ __new_dict | d({}) | combine(mutated_item) }}"
  loop: "{{ old_dict | dict2items }}"
  mutated_item: "{{ {item.key: mutation of item.value} }}"

- name: Reset original old dict
  set_fact:
    old_dict: "{{ __new_dict }}"
```

Another big change is that a boolean expression in a `when` or similar construct
must be converted to a boolean - we cannot rely on the implicit evaluation in
a boolean context.  For example, if `var` is some iterable, like a `dict`, `list`,
or `string`, you used to be able to evaluate an empty value in a boolean context:

```yaml
when: var  # do this only if var is not empty
```

You now have to explicitly test for empty using `length`:

```yaml
when: var | length > 0  # do this only if var is not empty
```

Similarly for `int` values - you cannot rely on `0` being evaluated as false
and non-zero true - you must explicitly compare the values with `==` or `!=`

These are the biggest changes.  See the porting guide for others.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Refactor task conditions and test assertions to comply with Ansible 2.19's requirements for explicit boolean evaluation and data immutability.

Enhancements:
- Convert implicit boolean `when` conditions in tasks to explicit null checks and length comparisons for Ansible 2.19 compatibility

Tests:
- Update SELinux module tests to use explicit `== 0` and `!= 0` assertions instead of relying on implicit truthiness