### PR TITLE
docs(changelog): version 1.9.0 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -278,6 +278,8 @@ SELinux user record range.</li>
 </ul>
 <p>Individual modifications can be dropped by setting <code>state</code>
 to <code>absent</code>.</p>
+<p>Note: The <code>selinux_fcontexts</code> option does not work in
+container builds.</p>
 <h2 id="selinux_ports">selinux_ports</h2>
 <p>Manage the state of SELinux port policy. This is a <code>list</code>
 of <code>dict</code>, where each <code>dict</code> is in the same format
@@ -356,6 +358,8 @@ Enterprise Linux 6</p>
 <p><strong>Note:</strong> Managing modules is idempotent only on Fedora,
 and EL 8.6 and later. You can manage modules on older releases, but it
 will not be idempotent.</p>
+<p>Note: The <code>selinux_modules</code> option does not work in
+container builds.</p>
 <h2
 id="selinux_transactional_update_reboot_ok">selinux_transactional_update_reboot_ok</h2>
 <p>This variable is used to handle reboots required by transactional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+[1.9.0] - 2025-06-16
+--------------------
+
+### New Features
+
+- feat: Partially support this role in container builds (#277)
+
+### Other Changes
+
+- ci: Add support for bootc end-to-end validation tests (#278)
+- tests: Add bootc end-to-end test (#279)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#280)
+- refactor: Ansible 2.19 support (#281)
+
 [1.8.3] - 2025-05-30
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.9.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare release 1.9.0 by documenting the new container build support, updating CI and tests for BootC and Ansible 2.19 compatibility, and noting SELinux feature limitations for container environments.

New Features:
- Partially support role execution in container builds

Enhancements:
- Refactor code for Ansible 2.19 compatibility

CI:
- Add BootC end-to-end validation tests
- Use Ansible 2.19 for Fedora 42 testing and support Python 3.13

Documentation:
- Update changelog for version 1.9.0
- Add notes in README about selinux_fcontexts and selinux_modules limitations in container builds

Tests:
- Add BootC end-to-end test