### PR TITLE
feat: Support selinux_fcontexts during bootc builds

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,6 +14,7 @@ kinds:
   - playbook: "**/examples/*.yml"
 skip_list:
   - fqcn-builtins
+  - name[unique]
   - var-naming[no-role-prefix]
 exclude_paths:
   - tests/roles/

--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ Users may also pass the following optional parameters:
 
 Individual modifications can be dropped by setting `state` to `absent`.
 
-Note: The `selinux_fcontexts` option does not work in container builds.
-
 ### selinux_ports
 
 Manage the state of SELinux port policy.  This is a `list` of `dict`, where each

--- a/tests/tests_bootc_e2e.yml
+++ b/tests/tests_bootc_e2e.yml
@@ -6,6 +6,9 @@
     - tests::bootc-e2e
   gather_facts: false
 
+  vars:
+    __selinux_sar_label_file: /var/sar-label-file
+
   tasks:
     # PREPARATION
     - name: Bootc image build preparation
@@ -15,6 +18,14 @@
           user:
             comment: System Api Roles SELinux User
             name: sar-user
+
+        - name: Create test file for relabeling
+          file:
+            path: "{{ __selinux_sar_label_file }}"
+            state: touch
+            owner: root
+            group: root
+            mode: '0644'
 
         - name: Modify SELinux policy
           include_role:
@@ -28,6 +39,8 @@
               - {login: 'sar-user', seuser: 'staff_u', state: 'present'}
             selinux_ports:
               - {ports: '22100', proto: 'tcp', setype: 'ssh_port_t', state: 'present'}
+            selinux_fcontexts:
+              - {target: "{{ __selinux_sar_label_file }}", setype: "var_spool_t"}
 
         - name: Create QEMU deployment
           delegate_to: localhost
@@ -67,3 +80,13 @@
               - selinux_role_boolean.stdout is match('^samba_enable_home_dirs.*on.*on')
               - selinux_role_login.stdout is match('^sar-user.*staff_u.*s0')
               - selinux_role_port.stdout is match('^ssh_port_t.*22100')
+
+        - name: Get SELinux context of label test file
+          command: "ls -Z {{ __selinux_sar_label_file }}"
+          register: sar_label_file_ls
+          changed_when: false
+
+        - name: Assert SELinux context of label test file
+          assert:
+            that:
+              - "sar_label_file_ls.stdout | trim == 'system_u:object_r:var_spool_t:s0 {{ __selinux_sar_label_file }}'"


### PR DESCRIPTION
Feature: Support setting file contexts during container builds.

Reason: This is particularly useful for building bootc derivative OSes.

Result: The `selinux_fcontexts` option is now officially supported for calling during a bootc container build.

This was in fact already working, just tests_restore_dirs is written in a way that cannot work during container builds (direct `chcon`/`ls` etc.). Add this to tests_bootc_e2e.

https://issues.redhat.com/browse/RHEL-95403

## Summary by Sourcery

Enable selinux_fcontexts support during bootc container builds by updating documentation and augmenting the end-to-end tests to create a test file, apply file contexts, and assert the correct SELinux label.

New Features:
- Officially support the selinux_fcontexts option in bootc container builds.

Documentation:
- Remove the outdated note in README stating selinux_fcontexts doesn’t work in container builds.

Tests:
- Add e2e test tasks to create a file, apply selinux_fcontexts, and verify its SELinux context in tests_bootc_e2e.yml.