### PR TITLE
test: use daemons_use_tcp_wrapper for seboolean tests

### DIFF
--- a/tests/tests_all_purge.yml
+++ b/tests/tests_all_purge.yml
@@ -4,7 +4,7 @@
   gather_facts: true
   vars:
     semanage_change: |
-      boolean -m --on samba_enable_home_dirs
+      boolean -m --on daemons_use_tcp_wrapper
       port -a -p tcp -t ssh_port_t 22100
       fcontext -a -t user_home_dir_t /tmp/test_dir
       login -a -s staff_u sar-user

--- a/tests/tests_boolean.yml
+++ b/tests/tests_boolean.yml
@@ -8,7 +8,7 @@
       vars:
         selinux_booleans_purge: true
         selinux_booleans:
-          - {name: 'samba_enable_home_dirs', state: 'on', persistent: 'yes'}
+          - {name: 'daemons_use_tcp_wrapper', state: 'on', persistent: 'yes'}
 
     - name: Include test variables
       import_tasks: set_selinux_variables.yml

--- a/tests/tests_bootc_e2e.yml
+++ b/tests/tests_bootc_e2e.yml
@@ -44,7 +44,7 @@
             # enforcing is the default, so change
             selinux_state: permissive
             selinux_booleans:
-              - {name: 'samba_enable_home_dirs', state: 'on', persistent: 'yes'}
+              - {name: 'daemons_use_tcp_wrapper', state: 'on', persistent: 'yes'}
             selinux_logins:
               - {login: 'sar-user', seuser: 'staff_u', state: 'present'}
             selinux_ports:
@@ -92,7 +92,7 @@
           assert:
             that:
               - getenforce.stdout | trim == "Permissive"
-              - selinux_role_boolean.stdout is match('^samba_enable_home_dirs.*on.*on')
+              - selinux_role_boolean.stdout is match('^daemons_use_tcp_wrapper.*on.*on')
               - selinux_role_login.stdout is match('^sar-user.*staff_u.*s0')
               - selinux_role_port.stdout is match('^ssh_port_t.*22100')
 

--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -10,7 +10,7 @@
     selinux_policy: targeted
     selinux_state: enforcing
     semanage_change: |
-      boolean -m --on samba_enable_home_dirs
+      boolean -m --on daemons_use_tcp_wrapper
       port -a -p tcp -t ssh_port_t 22100
       fcontext -a -t user_home_dir_t /tmp/test_dir
       login -a -s staff_u sar-user


### PR DESCRIPTION
daemons_use_tcp_wrapper is supported on all platforms including
automotive.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
