### PR TITLE
docs(changelog): version 1.10.0 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -278,8 +278,6 @@ SELinux user record range.</li>
 </ul>
 <p>Individual modifications can be dropped by setting <code>state</code>
 to <code>absent</code>.</p>
-<p>Note: The <code>selinux_fcontexts</code> option does not work in
-container builds.</p>
 <h2 id="selinux_ports">selinux_ports</h2>
 <p>Manage the state of SELinux port policy. This is a <code>list</code>
 of <code>dict</code>, where each <code>dict</code> is in the same format
@@ -358,8 +356,6 @@ Enterprise Linux 6</p>
 <p><strong>Note:</strong> Managing modules is idempotent only on Fedora,
 and EL 8.6 and later. You can manage modules on older releases, but it
 will not be idempotent.</p>
-<p>Note: The <code>selinux_modules</code> option does not work in
-container builds.</p>
 <h2
 id="selinux_transactional_update_reboot_ok">selinux_transactional_update_reboot_ok</h2>
 <p>This variable is used to handle reboots required by transactional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+[1.10.0] - 2025-06-23
+--------------------
+
+### New Features
+
+- feat: Support selinux_fcontexts during bootc builds (#283)
+- feat: Support selinux_modules during bootc builds (#284)
+
 [1.9.0] - 2025-06-16
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.10.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare for the 1.10.0 release by updating the CHANGELOG with new features and cleaning up outdated notes in the README HTML.

New Features:
- Add support for selinux_fcontexts during bootc builds
- Add support for selinux_modules during bootc builds

Documentation:
- Remove outdated notes about selinux_fcontexts and selinux_modules not working in container builds from README HTML

Chores:
- Update CHANGELOG and .README.html for version 1.10.0