### PR TITLE
Fix: Fix check mode

### DIFF
--- a/tasks/selinux_load_module.yml
+++ b/tasks/selinux_load_module.yml
@@ -35,6 +35,7 @@
 
     - name: Install module
       when: not module_file.stat.checksum in checksum
+      ignore_errors: "{{ ansible_check_mode }}"
       block:
         - name: Create temporary directory
           tempfile:


### PR DESCRIPTION
    Managing an selinux custom policy module with ansible doesn't work in
    check mode.  Instead of the expected behavior (which is a bit too much
    to ask) of telling you what changes the module would make, it dies
    with an error.

    This change doesn't generate the true expected behavior, but it has
    a much saner behavior of counting the potential selinux policy changes
    as errors which were ignored.  I need the ability to
    use check mode with diff mode to see what would happen.  Without this
    change, to use check mode in a playbook that assigns multiple roles,
    the selinux error would kill the playbook and leave the remaining
    tasks unchecked.  Yuck.

Enhancement:

Reason:

Result:

Issue Tracker Tickets (Jira or BZ if any):
