### PR TITLE
fix: tempdir path not defined in check mode; __selinux_item.path may be undefined

### DIFF
--- a/tasks/selinux_load_module.yml
+++ b/tasks/selinux_load_module.yml
@@ -42,11 +42,12 @@
             prefix: linux_system_role.selinux
           register: tempdir
 
-        - name: Copy module file {{ __selinux_item.path }}
+        - name: Copy module file {{ __selinux_item.path | d("EMPTY") }}
           copy:
             dest: "{{ tempdir.path }}"
             src: "{{ __selinux_item.path }}"
             mode: preserve
+          when: tempdir.path is defined
 
         - name: Install the module
           local_semodule:
@@ -54,11 +55,13 @@
             priority: "{{ priority }}"
             state: enabled
           notify: __selinux_reload_policy
+          when: tempdir.path is defined
       always:
-        - name: Clean temporary directory {{ tempdir.path }}
+        - name: Clean temporary directory {{ tempdir.path | d("EMPTY") }}
           file:
             path: "{{ tempdir.path }}"
             state: absent
+          when: tempdir.path is defined
 
 - name: Remove module
   local_semodule:


### PR DESCRIPTION
Cause: tempdir path is not defined in check mode, and __selinux_item.path may be undefined
in some cases.

Consequence: The role will give an error when running in check mode that various
variables are undefined.

Fix: Skip tasks that require tempdir.path to be defined.  Handle cases where variables
may be undefined.

Result: The role works in check mode.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enable Ansible check mode support in selinux_load_module by guarding against undefined tempdir.path and __selinux_item.path.

Bug Fixes:
- Guard copy, install, and cleanup tasks against undefined tempdir.path to prevent errors in check mode
- Provide a default for __selinux_item.path when copying modules to avoid undefined path errors

Enhancements:
- Skip filesystem operations requiring tempdir.path when it is not defined to improve check mode compatibility