### PR TITLE
test: ensure disabled selinux test restores system state

### DIFF
--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -111,18 +111,6 @@
         - name: Cleanup
           tags: ['tests::cleanup']
           block:
-            - name: Restore original /etc/selinux/config
-              copy:
-                remote_src: true
-                dest: /etc/selinux/config
-                src: /etc/selinux/config.test_selinux_disabled
-                mode: preserve
-
-            - name: Remove /etc/selinux/config backup
-              file:
-                path: /etc/selinux/config.test_selinux_disabled
-                state: absent
-
             - name: Remove Linux System Roles SELinux User
               user:
                 name: sar-user
@@ -136,3 +124,15 @@
                 selinux_all_purge: true
                 selinux_policy: "{{ __save_policy }}"
                 selinux_state: "{{ __save_state }}"
+
+            - name: Restore original /etc/selinux/config
+              copy:
+                remote_src: true
+                dest: /etc/selinux/config
+                src: /etc/selinux/config.test_selinux_disabled
+                mode: preserve
+
+            - name: Remove /etc/selinux/config backup
+              file:
+                path: /etc/selinux/config.test_selinux_disabled
+                state: absent

--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -5,16 +5,6 @@
     # (un)mounting SELinux fs does not work in container builds
     - tests::booted
   gather_facts: true
-  vars:
-    selinux_all_purge: true
-    selinux_policy: targeted
-    selinux_state: enforcing
-    semanage_change: |
-      boolean -m --on daemons_use_tcp_wrapper
-      port -a -p tcp -t ssh_port_t 22100
-      fcontext -a -t user_home_dir_t /tmp/test_dir
-      login -a -s staff_u sar-user
-
   tasks:
     - name: Ensure SELinux test packages
       include_tasks:
@@ -23,96 +13,126 @@
         __selinux_get_test_facts: false
         __selinux_need_findmnt: true
 
-    - name: Add a Linux System Roles SELinux User
-      user:
-        comment: Linux System Roles SELinux User
-        name: sar-user
-    - name: Add some mapping
-      shell: |-
-        set -euo pipefail
-        echo -e -n "{{ semanage_change }}" | /usr/sbin/semanage -i -
-      changed_when: false
-    - name: Backup original /etc/selinux/config
-      copy:
-        remote_src: true
-        src: /etc/selinux/config
-        dest: /etc/selinux/config.test_selinux_disabled
-        mode: preserve
-    - name: Upload testing /etc/selinux/config
-      copy:
-        src: selinux.config
-        dest: /etc/selinux/config
-        mode: preserve
-    - name: Switch to permissive to allow login when selinuxfs is not mounted
-      command: setenforce 0
-      changed_when: false
-      when: ansible_selinux.status != "disabled"
-    - name: Get selinuxfs mountpoint
-      command: findmnt -n -t selinuxfs --output=target
-      changed_when: false
-      register: selinux_mountpoint
-    - name: >-
-        Umount selinux mountpoint to emulate SELinux disabled
-        system {{ selinux_mountpoint.stdout }}
-      command: umount -l {{ selinux_mountpoint.stdout }}
-      changed_when: false
+    - name: Get current SELinux state
+      set_fact:
+        __save_policy: "{{ ansible_selinux.type }}"
+        __save_state: "{{ ansible_selinux.config_mode }}"
 
-    - name: Execute the role and catch errors
+    - name: Run the tests
       block:
-        - name: Include role
-          include_role:
-            name: linux-system-roles.selinux
-      rescue:
-        - name: Examine the selinux_reboot_required variable
-          set_fact:
-            test_selinux_reboot_required: "{{ selinux_reboot_required }}"
+        - name: Add a Linux System Roles SELinux User
+          user:
+            comment: Linux System Roles SELinux User
+            name: sar-user
 
-    - name: Check that the role has failed and set the correct variable
-      assert:
-        that: test_selinux_reboot_required | bool
-        msg: "test_selinux_reboot_required should be True instead of
-              {{ test_selinux_reboot_required }}"
-    - name: >-
-        Mount selinux mountpoint back to
-        system {{ selinux_mountpoint.stdout }}
-      # noqa command-instead-of-module
-      command: >-
-        mount -t selinuxfs selinuxfs {{ selinux_mountpoint.stdout }}
-      changed_when: false
-    - name: Switch back to enforcing
-      command: setenforce 1
-      changed_when: false
-    - name: Gather facts again
-      setup:
-    - name: Check SELinux config mode
-      assert:
-        that: ansible_selinux.config_mode == 'enforcing'
-        msg: "SELinux config mode should be enforcing instead of
-              {{ ansible_selinux.config_mode }}"
+        - name: Add some mapping
+          shell: |-
+            set -euo pipefail
+            echo -e -n "{{ semanage_change }}" | /usr/sbin/semanage -i -
+          changed_when: false
+          vars:
+            semanage_change: |
+              boolean -m --on daemons_use_tcp_wrapper
+              port -a -p tcp -t ssh_port_t 22100
+              fcontext -a -t user_home_dir_t /tmp/test_dir
+              login -a -s staff_u sar-user
 
-    - name: Cleanup
-      tags: ['tests::cleanup']
-      block:
-        - name: Restore original /etc/selinux/config
+        - name: Backup original /etc/selinux/config
           copy:
             remote_src: true
-            dest: /etc/selinux/config
-            src: /etc/selinux/config.test_selinux_disabled
+            src: /etc/selinux/config
+            dest: /etc/selinux/config.test_selinux_disabled
             mode: preserve
 
-        - name: Remove /etc/selinux/config backup
-          file:
-            path: /etc/selinux/config.test_selinux_disabled
-            state: absent
+        - name: Upload testing /etc/selinux/config
+          copy:
+            src: selinux.config
+            dest: /etc/selinux/config
+            mode: preserve
 
-        - name: Remove Linux System Roles SELinux User
-          user:
-            name: sar-user
-            remove: true
-            state: absent
+        - name: Switch to permissive to allow login when selinuxfs is not mounted
+          command: setenforce 0
+          changed_when: false
+          when: ansible_selinux.status != "disabled"
 
-        - name: Include role to purge everything
-          include_role:
-            name: linux-system-roles.selinux
-          vars:
-            selinux_all_purge: true
+        - name: Get selinuxfs mountpoint
+          command: findmnt -n -t selinuxfs --output=target
+          changed_when: false
+          register: selinux_mountpoint
+
+        - name: >-
+            Umount selinux mountpoint to emulate SELinux disabled
+            system {{ selinux_mountpoint.stdout }}
+          command: umount -l {{ selinux_mountpoint.stdout }}
+          changed_when: false
+
+        - name: Execute the role and catch errors
+          block:
+            - name: Include role
+              include_role:
+                name: linux-system-roles.selinux
+              vars:
+                selinux_policy: targeted
+                selinux_state: enforcing
+                selinux_all_purge: true
+          rescue:
+            - name: Examine the selinux_reboot_required variable
+              set_fact:
+                test_selinux_reboot_required: "{{ selinux_reboot_required }}"
+
+        - name: Check that the role has failed and set the correct variable
+          assert:
+            that: test_selinux_reboot_required | bool
+            msg: "test_selinux_reboot_required should be True instead of
+                  {{ test_selinux_reboot_required }}"
+
+        - name: >-
+            Mount selinux mountpoint back to
+            system {{ selinux_mountpoint.stdout }}
+          # noqa command-instead-of-module
+          command: >-
+            mount -t selinuxfs selinuxfs {{ selinux_mountpoint.stdout }}
+          changed_when: false
+
+        - name: Switch back to enforcing
+          command: setenforce 1
+          changed_when: false
+
+        - name: Gather facts again
+          setup:
+
+        - name: Check SELinux config mode
+          assert:
+            that: ansible_selinux.config_mode == 'enforcing'
+            msg: "SELinux config mode should be enforcing instead of
+                  {{ ansible_selinux.config_mode }}"
+
+      always:
+        - name: Cleanup
+          tags: ['tests::cleanup']
+          block:
+            - name: Restore original /etc/selinux/config
+              copy:
+                remote_src: true
+                dest: /etc/selinux/config
+                src: /etc/selinux/config.test_selinux_disabled
+                mode: preserve
+
+            - name: Remove /etc/selinux/config backup
+              file:
+                path: /etc/selinux/config.test_selinux_disabled
+                state: absent
+
+            - name: Remove Linux System Roles SELinux User
+              user:
+                name: sar-user
+                remove: true
+                state: absent
+
+            - name: Include role to purge everything
+              include_role:
+                name: linux-system-roles.selinux
+              vars:
+                selinux_all_purge: true
+                selinux_policy: "{{ __save_policy }}"
+                selinux_state: "{{ __save_state }}"


### PR DESCRIPTION
Save the state and the policy before the test, and ensure we
restore that after the test.

Put the cleanup block in a `always` so that it will always be
executed, even if the test fails.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Improve the disabled SELinux test by capturing pre-test system state and enforcing cleanup in an always block to guarantee restoration of SELinux configuration, mountpoints, and test user regardless of test outcome

Enhancements:
- Save original SELinux policy and state before running the disabled SELinux test and restore them afterward
- Wrap test steps in a block with an always cleanup section to ensure system state is restored even if the test fails

Tests:
- Refactor the disabled SELinux test to remove global vars and inline semanage_change within the test block