### PR TITLE
test: restore selinux config file in proper context

### DIFF
--- a/tests/selinux_config_restore.yml
+++ b/tests/selinux_config_restore.yml
@@ -5,6 +5,10 @@
     dest: /etc/selinux/config
     src: /etc/selinux/config.test_selinux_save
     mode: preserve
+    selevel: _default
+    serole: _default
+    setype: _default
+    seuser: _default
   register: restorecon
 
 - name: Remove /etc/selinux/config backup

--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -49,6 +49,10 @@
             src: selinux.config
             dest: /etc/selinux/config
             mode: preserve
+            selevel: _default
+            serole: _default
+            setype: _default
+            seuser: _default
 
         - name: Switch to permissive to allow login when selinuxfs is not mounted
           command: setenforce 0
@@ -131,6 +135,10 @@
                 dest: /etc/selinux/config
                 src: /etc/selinux/config.test_selinux_disabled
                 mode: preserve
+                selevel: _default
+                serole: _default
+                setype: _default
+                seuser: _default
 
             - name: Remove /etc/selinux/config backup
               file:


### PR DESCRIPTION
Use _default SELinux level, role, type and user when copy into /etc/selinux/config for ensuring that file has proper SELinux context.

Enhancement:

Reason:
Solves AVCs after tests_selinux_disabled.yml is executed

Result:
No AVCs

Issue Tracker Tickets (Jira or BZ if any):
