### PR TITLE
docs(changelog): version 1.10.5 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 Changelog
 =========
 
+[1.10.5] - 2025-11-17
+--------------------
+
+### Bug Fixes
+
+- fix: cannot use community-general version 12 - no py27 and py36 support (#312)
+
+### Other Changes
+
+- ci: bump actions/checkout from 4 to 5 (#296)
+- ci: rollout several recent changes to CI testing (#298)
+- ci: support openSUSE Leap in qemu/kvm test matrix (#299)
+- ci: use the new epel feature to enable EPEL for testing farm (#300)
+- ci: use tox-lsr 3.12.0 for osbuild_config.yml feature (#302)
+- ci: use JSON format for __bootc_validation (#303)
+- ci: bump actions/setup-python from 5 to 6 (#305)
+- ci: bump actions/github-script from 7 to 8 (#306)
+- ci: bump actions/upload-artifact from 4 to 5 (#307)
+- ci: bump github/codeql-action from 3 to 4 (#308)
+- ci: use versioned upload-artifact instead of master; bump codeql-action to v4; bump upload-artifact to v5 (#309)
+- ci: bump tox-lsr to 3.13.0 (#310)
+- ci: bump tox-lsr to 3.14.0 - this moves standard-inventory-qcow2 to tox-lsr (#311)
+
 [1.10.4] - 2025-08-18
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.10.5

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare and document the 1.10.5 release by updating the changelog and README, including one bug fix and multiple CI tooling enhancements.

Bug Fixes:
- Fix community-general version 12 to restore support for py27 and py36 (#312)

CI:
- Bump various GitHub Actions (checkout, setup-python, github-script, upload-artifact, codeql-action) to their latest versions
- Roll out recent CI testing changes and support openSUSE Leap in the qemu/kvm test matrix
- Enable EPEL for the testing farm via the new epel feature and switch JSON format for __bootc_validation
- Update tox-lsr to versions 3.12.0, 3.13.0, and 3.14.0 (including moving standard-inventory-qcow2 into tox-lsr)

Documentation:
- Update CHANGELOG.md and README.html for version 1.10.5