### PR TITLE
ci: add qemu tests for Fedora 43, drop Fedora 41

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -27,9 +27,8 @@ jobs:
           # QEMU
           - { image: "centos-9", env: "qemu-ansible-core-2.16" }
           - { image: "centos-10", env: "qemu-ansible-core-2.17" }
-          # ansible/libdnf5 bug: https://issues.redhat.com/browse/RHELMISC-10110
-          # - { image: "fedora-41", env: "qemu-ansible-core-2.17" }
           - { image: "fedora-42", env: "qemu-ansible-core-2.19" }
+          - { image: "fedora-43", env: "qemu-ansible-core-2.19" }
           - { image: "leap-15.6", env: "qemu-ansible-core-2.18" }
 
           # container
@@ -38,10 +37,10 @@ jobs:
           # broken on non-running dbus
           # - { image: "centos-10", env: "container-ansible-core-2.17" }
           - { image: "centos-10-bootc", env: "container-ansible-core-2.17" }
-          - { image: "fedora-41", env: "container-ansible-core-2.17" }
           - { image: "fedora-42", env: "container-ansible-core-2.17" }
-          - { image: "fedora-41-bootc", env: "container-ansible-core-2.17" }
+          - { image: "fedora-43", env: "container-ansible-core-2.19" }
           - { image: "fedora-42-bootc", env: "container-ansible-core-2.17" }
+          - { image: "fedora-43-bootc", env: "container-ansible-core-2.19" }
 
     env:
       TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"


### PR DESCRIPTION
add qemu tests for Fedora 43, drop Fedora 41

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update QEMU integration test matrix to target newer Fedora images and ansible-core versions.

CI:
- Add Fedora 43 QEMU and container images (including bootc) to the integration test matrix.
- Remove Fedora 41 QEMU and container images from the integration test matrix.
- Align Fedora 43 container tests with ansible-core 2.19.