### PR TITLE
refactor: handle INJECT_FACTS_AS_VARS=false by using ansible_facts instead

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: Reload SELinux policy
   command: semodule -R
   listen: __selinux_reload_policy
-  when: ansible_selinux.status != "disabled"
+  when: ansible_facts['selinux']['status'] != "disabled"
   changed_when: true

--- a/tasks/ensure_selinux_packages.yml
+++ b/tasks/ensure_selinux_packages.yml
@@ -31,7 +31,7 @@
     state: present
     use: "{{ (__selinux_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: ansible_python_version is version('3', '<')
+  when: ansible_facts['python_version'] is version('3', '<')
 
 - name: Install SELinux python3 tools
   package:
@@ -42,8 +42,8 @@
     use: "{{ (__selinux_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
-    - ansible_python_version is version('3', '>=')
-    - ansible_os_family == "RedHat"
+    - ansible_facts['python_version'] is version('3', '>=')
+    - ansible_facts['os_family'] == "RedHat"
 
 - name: Install SELinux python3 tools
   package:
@@ -54,8 +54,8 @@
     use: "{{ (__selinux_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
-    - ansible_python_version is version('3', '>=')
-    - ansible_os_family == "Suse"
+    - ansible_facts['python_version'] is version('3', '>=')
+    - ansible_facts['os_family'] == "Suse"
   register: selinux_python3_tools_result
 
 - name: Ensure grubby used to modify selinux kernel parameter
@@ -75,10 +75,10 @@
     state: present
     use: "{{ (__selinux_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: ansible_distribution == "Fedora" or
-    ansible_distribution == "SL-Micro" or
-    (ansible_distribution_major_version | int > 7 and
-     ansible_distribution in ["CentOS", "RedHat", "Rocky"])
+  when: ansible_facts['distribution'] == "Fedora" or
+    ansible_facts['distribution'] == "SL-Micro" or
+    (ansible_facts['distribution_major_version'] | int > 7 and
+     ansible_facts['distribution'] in ["CentOS", "RedHat", "Rocky"])
   register: selinux_semanage_result
 
 - name: Handle reboot for transactional update systems

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,12 +31,12 @@
     - name: Set permanent SELinux state if enabled
       # noqa args[module] fqcn[action]
       selinux:
-        state: "{{ selinux_state | default(ansible_selinux.config_mode, true) }}"
-        policy: "{{ selinux_policy | default(ansible_selinux.type, true) }}"
+        state: "{{ selinux_state | default(ansible_facts['selinux']['config_mode'], true) }}"
+        policy: "{{ selinux_policy | default(ansible_facts['selinux']['type'], true) }}"
         update_kernel_param: "{{ true if __update_kernel_param else omit }}"
       register: selinux_mod_output_enabled
       when:
-        - ansible_selinux.status == "enabled"
+        - ansible_facts['selinux']['status'] == "enabled"
         - (not selinux_state is none and selinux_state | length > 0) or
           (not selinux_policy is none and selinux_policy | length > 0)
 
@@ -48,7 +48,7 @@
         update_kernel_param: "{{ true if __update_kernel_param else omit }}"
       register: selinux_mod_output_disabled
       when:
-        - ansible_selinux.status == "disabled"
+        - ansible_facts['selinux']['status'] == "disabled"
         - not selinux_state is none
         - selinux_state | length > 0
 
@@ -84,7 +84,7 @@
 - name: Warn if SELinux is disabled
   debug:
     msg: "SELinux is disabled on system - some SELinux modules can crash"
-  when: ansible_selinux.status == "disabled"
+  when: ansible_facts['selinux']['status'] == "disabled"
 
 - name: Drop all local modifications
   command: /usr/sbin/semanage -i -
@@ -120,8 +120,8 @@
     name: "{{ __selinux_item.name }}"
     state: "{{ __selinux_item.state }}"
     persistent: "{{ __selinux_item.persistent |
-                  default(ansible_selinux.status == 'disabled') }}"
-    ignore_selinux_state: "{{ ansible_selinux.status == 'disabled' }}"
+                  default(ansible_facts['selinux']['status'] == 'disabled') }}"
+    ignore_selinux_state: "{{ ansible_facts['selinux']['status'] == 'disabled' }}"
   with_items: "{{ selinux_booleans }}"
   loop_control:
     loop_var: __selinux_item
@@ -134,7 +134,7 @@
     state: "{{ __selinux_item.state | default('present') }}"
     selevel: "{{ __selinux_item.selevel | default(omit) }}"
     seuser: "{{ __selinux_item.seuser | default(omit) }}"
-    ignore_selinux_state: "{{ ansible_selinux.status == 'disabled' }}"
+    ignore_selinux_state: "{{ ansible_facts['selinux']['status'] == 'disabled' }}"
   with_items: "{{ selinux_fcontexts }}"
   loop_control:
     loop_var: __selinux_item
@@ -146,7 +146,7 @@
     setype: "{{ __selinux_item.setype }}"
     state: "{{ __selinux_item.state | default('present') }}"
     local: "{{ __selinux_item.local | default(False) }}"
-    ignore_selinux_state: "{{ ansible_selinux.status == 'disabled' }}"
+    ignore_selinux_state: "{{ ansible_facts['selinux']['status'] == 'disabled' }}"
   with_items: "{{ selinux_ports }}"
   loop_control:
     loop_var: __selinux_item
@@ -158,7 +158,7 @@
     serange: "{{ __selinux_item.serange | default('s0') }}"
     state: "{{ __selinux_item.state | default('present') }}"
     reload: "{{ __selinux_item.reload | default(False) }}"
-    ignore_selinux_state: "{{ ansible_selinux.status == 'disabled' }}"
+    ignore_selinux_state: "{{ ansible_facts['selinux']['status'] == 'disabled' }}"
   with_items: "{{ selinux_logins }}"
   notify: __selinux_reload_policy
   loop_control:
@@ -166,6 +166,14 @@
 
 - name: Get SELinux modules facts
   selinux_modules_facts:
+
+# This is a workaround to set the SELinux modules facts after the selinux_modules_facts module is executed
+# because with newer version of Ansible facts are no longer set as variables
+- name: Set SELinux modules facts
+  set_fact:
+    selinux_installed_modules: "{{ ansible_facts['selinux_installed_modules'] }}"
+    selinux_priorities: "{{ ansible_facts['selinux_priorities'] }}"
+    selinux_checksums: "{{ ansible_facts['selinux_checksums'] }}"
 
 - name: Load SELinux modules
   include_tasks: selinux_load_module.yml

--- a/tasks/selinux_load_module.yml
+++ b/tasks/selinux_load_module.yml
@@ -87,3 +87,11 @@
 
 - name: Refresh SELinux modules facts
   selinux_modules_facts:
+
+# This is a workaround to set the SELinux modules facts after the selinux_modules_facts module is executed
+# because with newer version of Ansible facts are no longer set as variables
+- name: Set SELinux modules facts
+  set_fact:
+    selinux_installed_modules: "{{ ansible_facts['selinux_installed_modules'] }}"
+    selinux_priorities: "{{ ansible_facts['selinux_priorities'] }}"
+    selinux_checksums: "{{ ansible_facts['selinux_checksums'] }}"

--- a/tests/selinux_test_transitions.yml
+++ b/tests/selinux_test_transitions.yml
@@ -17,12 +17,12 @@
 - name: Check that initial state has been set up properly
   assert:
     that:
-      selinux_initial_state == (ansible_selinux.mode | d(ansible_selinux.status))
+      selinux_initial_state == (ansible_facts['selinux']['mode'] | d(ansible_facts['selinux']['status']))
 # yamllint enable rule:line-length
 
 - name: Save the initial state
   set_fact:
-    initial_selinux_fact: "{{ ansible_selinux }}"
+    initial_selinux_fact: "{{ ansible_facts['selinux'] }}"
 
 - name: Apply the role without parameters
   include_role:
@@ -34,7 +34,7 @@
 
 - name: Check that the run w/o parameters has not changed anything
   assert:
-    that: ansible_selinux == initial_selinux_fact
+    that: ansible_facts['selinux'] == initial_selinux_fact
 
 - name: Apply the desired state if possible without reboot
   include_role:
@@ -59,22 +59,22 @@
 
 - name: Check that something changed if it should have
   assert:
-    that: ansible_selinux != initial_selinux_fact
+    that: ansible_facts['selinux'] != initial_selinux_fact
   when: selinux_initial_state != selinux_desired_state
 
 - name: Check that nothing changed if it should not have
   assert:
-    that: ansible_selinux == initial_selinux_fact
+    that: ansible_facts['selinux'] == initial_selinux_fact
   when: selinux_initial_state == selinux_desired_state
 
 - name: Check that desired state has been applied properly
   assert:
     that:
-      selinux_desired_state == ansible_selinux.mode | d(ansible_selinux.status)
+      selinux_desired_state == ansible_facts['selinux']['mode'] | d(ansible_facts['selinux']['status'])
 
 # yamllint disable rule:line-length
 - name: Check that desired state has been saved properly
   assert:
     that:
-      selinux_desired_state == (ansible_selinux.config_mode | d(ansible_selinux.status))
+      selinux_desired_state == (ansible_facts['selinux']['config_mode'] | d(ansible_facts['selinux']['status']))
 # yamllint enable rule:line-length

--- a/tests/tests_all_transitions.yml
+++ b/tests/tests_all_transitions.yml
@@ -35,8 +35,8 @@
 
     - name: Save selinux state before test
       set_fact:
-        __state_before: "{{ ansible_selinux.mode | d(ansible_selinux.status) }}"
-        __type_before: "{{ ansible_selinux.type }}"
+        __state_before: "{{ ansible_facts['selinux']['mode'] | d(ansible_facts['selinux']['status']) }}"
+        __type_before: "{{ ansible_facts['selinux']['type'] }}"
 
     - name: See if we can use update_kernel_param
       set_fact:

--- a/tests/tests_modifications_with_selinux_disabled.yml
+++ b/tests/tests_modifications_with_selinux_disabled.yml
@@ -29,8 +29,8 @@
     - name: Switch to permissive to allow login when selinuxfs is not mounted
       command: setenforce 0
       changed_when: true
-      when: ansible_selinux.status != "disabled" and
-        ansible_selinux.mode != "permissive"
+      when: ansible_facts['selinux']['status'] != "disabled" and
+        ansible_facts['selinux']['mode'] != "permissive"
       register: selinux_switch_to_enforcing
     - name: Get selinuxfs mountpoint
       command: findmnt -n -t selinuxfs --output=target

--- a/tests/tests_selinux_disabled.yml
+++ b/tests/tests_selinux_disabled.yml
@@ -15,8 +15,8 @@
 
     - name: Get current SELinux state
       set_fact:
-        __save_policy: "{{ ansible_selinux.type }}"
-        __save_state: "{{ ansible_selinux.config_mode }}"
+        __save_policy: "{{ ansible_facts['selinux']['type'] }}"
+        __save_state: "{{ ansible_facts['selinux']['config_mode'] }}"
 
     - name: Run the tests
       block:
@@ -57,7 +57,7 @@
         - name: Switch to permissive to allow login when selinuxfs is not mounted
           command: setenforce 0
           changed_when: false
-          when: ansible_selinux.status != "disabled"
+          when: ansible_facts['selinux']['status'] != "disabled"
 
         - name: Get selinuxfs mountpoint
           command: findmnt -n -t selinuxfs --output=target
@@ -107,9 +107,9 @@
 
         - name: Check SELinux config mode
           assert:
-            that: ansible_selinux.config_mode == 'enforcing'
+            that: ansible_facts['selinux']['config_mode'] == 'enforcing'
             msg: "SELinux config mode should be enforcing instead of
-                  {{ ansible_selinux.config_mode }}"
+                  {{ ansible_facts['selinux']['config_mode'] }}"
 
       always:
         - name: Cleanup

--- a/tests/tests_selinux_modules.yml
+++ b/tests/tests_selinux_modules.yml
@@ -25,9 +25,9 @@
           - {path: "{{ playbook_dir }}/files/selinux_modules/linux-system-roles-selinux-test-c.pp", priority: "600"}
           - {name: "linux-system-roles-selinux-test-c", priority: "600",
              state: "absent"}
-      when: ansible_distribution == "Fedora" or
-        (ansible_distribution_major_version | int >= 7 and
-         ansible_distribution in ["CentOS", "RedHat", "Rocky"])
+      when: ansible_facts['distribution'] == "Fedora" or
+        (ansible_facts['distribution_major_version'] | int >= 7 and
+         ansible_facts['distribution'] in ["CentOS", "RedHat", "Rocky"])
       block:
         - name: Execute the role
           include_role:
@@ -51,9 +51,9 @@
         test_module_c: "{{ selinux_installed_modules
           ['linux-system-roles-selinux-test-c']['600']
           | default('absent') }}"
-      when: ansible_distribution == "Fedora" or
-        (ansible_distribution_major_version | int >= 7 and
-         ansible_distribution in ["CentOS", "RedHat", "Rocky"])
+      when: ansible_facts['distribution'] == "Fedora" or
+        (ansible_facts['distribution_major_version'] | int >= 7 and
+         ansible_facts['distribution'] in ["CentOS", "RedHat", "Rocky"])
       block:
         - name: "Check if linux-system-roles-selinux-test-a is installed and
           enabled"
@@ -93,8 +93,8 @@
           - {path: "{{ playbook_dir }}/files/selinux_modules/linux-system-roles-selinux-test-c.pp", priority: "200"}
           - {name: "linux-system-roles-selinux-test-c", priority: "300",
              state: "absent"}
-      when: ansible_distribution_major_version | int < 7 and
-        ansible_distribution in ["CentOS", "RedHat"]
+      when: ansible_facts['distribution_major_version'] | int < 7 and
+        ansible_facts['distribution'] in ["CentOS", "RedHat"]
       block:
         - name: Execute the role
           include_role:
@@ -118,8 +118,8 @@
         test_module_c: "{{ selinux_installed_modules
           ['linux-system-roles-selinux-test-c']['0']
           | default('absent') }}"
-      when: ansible_distribution_major_version | int < 7 and
-        ansible_distribution in ["CentOS", "RedHat"]
+      when: ansible_facts['distribution_major_version'] | int < 7 and
+        ansible_facts['distribution'] in ["CentOS", "RedHat"]
       block:
         - name: "Check if linux-system-roles-selinux-test-a is installed and
           enabled"

--- a/tests/tests_selinux_modules_checksum.yml
+++ b/tests/tests_selinux_modules_checksum.yml
@@ -16,9 +16,9 @@
       when: not ansible_facts.keys() | list |
         intersect(__selinux_test_facts) == __selinux_test_facts
     - name: Execute the role and catch errors
-      when: ansible_distribution == "Fedora" or
-        (ansible_distribution in ["CentOS", "RedHat", "Rocky"] and
-        ansible_distribution_version is version("8.6", ">="))
+      when: ansible_facts['distribution'] == "Fedora" or
+        (ansible_facts['distribution'] in ["CentOS", "RedHat", "Rocky"] and
+        ansible_facts['distribution_version'] is version("8.6", ">="))
       vars:
         selinux_modules:
           - {path: "selinux_modules/linux-system-roles-selinux-test-a.pp"}

--- a/tests/vars/rh_distros_vars.yml
+++ b/tests/vars/rh_distros_vars.yml
@@ -14,7 +14,7 @@ __selinux_rh_distros:
 __selinux_rh_distros_fedora: "{{ __selinux_rh_distros + ['Fedora'] }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone
-__selinux_is_rh_distro: "{{ ansible_distribution in __selinux_rh_distros }}"
+__selinux_is_rh_distro: "{{ ansible_facts['distribution'] in __selinux_rh_distros }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
-__selinux_is_rh_distro_fedora: "{{ ansible_distribution in __selinux_rh_distros_fedora }}"
+__selinux_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __selinux_rh_distros_fedora }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,10 +18,10 @@ __selinux_required_facts:
 __selinux_required_facts_subsets: "{{ ['!all', '!min'] +
   __selinux_required_facts }}"
 
-restorecon_threads: "{{ '-T 0' if ansible_distribution == 'Fedora' or
-  ansible_distribution == 'SL-Micro' or
-  (ansible_distribution_major_version | int > 8 and
-  ansible_distribution in ['CentOS', 'RedHat', 'Rocky']) else '' }}"
+restorecon_threads: "{{ '-T 0' if ansible_facts['distribution'] == 'Fedora' or
+  ansible_facts['distribution'] == 'SL-Micro' or
+  (ansible_facts['distribution_major_version'] | int > 8 and
+  ansible_facts['distribution'] in ['CentOS', 'RedHat', 'Rocky']) else '' }}"
 
 # BEGIN - DO NOT EDIT THIS BLOCK - rh distros variables
 # Ansible distribution identifiers that the role treats like RHEL
@@ -35,8 +35,8 @@ __selinux_rh_distros:
 __selinux_rh_distros_fedora: "{{ __selinux_rh_distros + ['Fedora'] }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone
-__selinux_is_rh_distro: "{{ ansible_distribution in __selinux_rh_distros }}"
+__selinux_is_rh_distro: "{{ ansible_facts['distribution'] in __selinux_rh_distros }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
-__selinux_is_rh_distro_fedora: "{{ ansible_distribution in __selinux_rh_distros_fedora }}"
+__selinux_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __selinux_rh_distros_fedora }}"
 # END - DO NOT EDIT THIS BLOCK - rh distros variables


### PR DESCRIPTION
Ansible 2.20 has deprecated the use of Ansible facts as variables.  For
example, `ansible_distribution` is now deprecated in favor of
`ansible_facts["distribution"]`.  This is due to making the default
setting `INJECT_FACTS_AS_VARS=false`.  For now, this will create WARNING
messages, but in Ansible 2.24 it will be an error.

Set facts returned from selinux_modules_facts explicitly with set_fact since
they are no longer implicitly set.

See https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.20.html#inject-facts-as-vars

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update SELinux role and tests to use structured ansible_facts instead of legacy fact variables for compatibility with newer Ansible versions.

Enhancements:
- Replace deprecated top-level fact variables with ansible_facts lookups across SELinux tasks, handlers, variables, and tests.
- Explicitly set SELinux modules-related facts after selinux_modules_facts runs to preserve existing role behavior under INJECT_FACTS_AS_VARS=false.