### PR TITLE
ci: use ANSIBLE_INJECT_FACT_VARS=false by default for testing

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -44,6 +44,7 @@ jobs:
 
     env:
       TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"
+      ANSIBLE_INJECT_FACT_VARS: "false"
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -168,6 +168,7 @@ jobs:
             SR_ARTIFACTS_DIR=${{ steps.set_vars.outputs.ARTIFACTS_DIR }};\
             SR_TEST_LOCAL_CHANGES=false;\
             SR_LSR_USER=${{ vars.SR_LSR_USER }};\
+            SR_ANSIBLE_INJECT_FACT_VARS=false;\
             SR_ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }}"
           # Note that LINUXSYSTEMROLES_SSH_KEY must be single-line, TF doesn't read multi-line variables fine.
           secrets: "SR_LSR_DOMAIN=${{ secrets.SR_LSR_DOMAIN }};\

--- a/README-ostree.md
+++ b/README-ostree.md
@@ -20,8 +20,8 @@ Usage:
 .ostree/get_ostree_data.sh packages runtime DISTRO-VERSION FORMAT
 ```
 
-`DISTRO-VERSION` is in the format that Ansible uses for `ansible_distribution`
-and `ansible_distribution_version` - for example, `Fedora-38`, `CentOS-8`,
+`DISTRO-VERSION` is in the format that Ansible uses for `ansible_facts["distribution"]`
+and `ansible_facts["distribution_version"]` - for example, `Fedora-38`, `CentOS-8`,
 `RedHat-9.4`
 
 `FORMAT` is one of `toml`, `json`, `yaml`, `raw`


### PR DESCRIPTION
Ansible 2.20 has deprecated the use of Ansible facts as variables.  For
example, `ansible_distribution` is now deprecated in favor of
`ansible_facts["distribution"]`.  This is due to making the default
setting `INJECT_FACTS_AS_VARS=false`.  For now, this will create WARNING
messages, but in Ansible 2.24 it will be an error.

In order to ensure that commits and PRs conform to this, use
ANSIBLE_INJECT_FACT_VARS=false by default in our CI testing.

Update README-ostree.md if needed.

See https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.20.html#inject-facts-as-vars

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Align CI testing and documentation with Ansible’s deprecation of facts-as-vars by defaulting to non-injected facts and updating references to fact variable names.

CI:
- Set ANSIBLE_INJECT_FACT_VARS=false in qemu-kvm integration tests workflow to match upcoming Ansible defaults.
- Propagate the non-injected facts configuration into TFT workflow via SR_ANSIBLE_INJECT_FACT_VARS to ensure consistent behavior in CI.

Documentation:
- Clarify README-ostree.md to reference ansible_facts["distribution"] and ansible_facts["distribution_version"] instead of deprecated fact variables.