### PR TITLE
docs(changelog): version 1.12.0 [citest_skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 Changelog
 =========
 
+[1.12.0] - 2026-04-28
+--------------------
+
+### New Features
+
+- feat: add role fingerprints to syslog (#345)
+
+### Other Changes
+
+- ci: bump actions/upload-artifact from 6 to 7 (#334)
+- ci: tox-lsr 3.17.0 - container test improvements, use ansible 2.20 for fedora 43 [citest_skip] (#336)
+- ci: tox-lsr 3.17.1 - previous update broke container tests, this fixes them [citest_skip] (#337)
+- test: ensure role gathers the facts it uses by having test clear_facts before include_role (#338)
+- ci: fix yum repos to use devel site instead of old site name [citest_skip] (#340)
+- ci: use codecov @v6 [citest_skip] (#341)
+- ci: update header for run_role_with_clear_facts [citest_skip] (#342)
+- ci: Comply with Ansible partner certification checking [citest_skip] (#343)
+- ci: ansible-lint requires dependencies to be installed [citest_skip] (#344)
+
 [1.11.1] - 2026-02-18
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.12.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Documentation:
- Add 1.12.0 release notes to the changelog, including the new role fingerprint syslog feature and CI/test-related updates.