### PR TITLE
fix: add verbosity-based no_log to facts modules

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -166,6 +166,7 @@
 
 - name: Get SELinux modules facts
   selinux_modules_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 # This is a workaround to set the SELinux modules facts after the selinux_modules_facts module is executed
 # because with newer version of Ansible facts are no longer set as variables

--- a/tasks/selinux_load_module.yml
+++ b/tasks/selinux_load_module.yml
@@ -87,6 +87,7 @@
 
 - name: Refresh SELinux modules facts
   selinux_modules_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 # This is a workaround to set the SELinux modules facts after the selinux_modules_facts module is executed
 # because with newer version of Ansible facts are no longer set as variables


### PR DESCRIPTION
Feature: Add verbosity-based no_log to facts modules.

Reason: Facts modules like selinux_modules_facts produce verbose output that clutters logs during normal operation, making it difficult to review playbook execution.

Result:
  - selinux_modules_facts now uses no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - Users can still see full facts output when debugging by running with increased verbosity
  - No impact on normal operation, just cleaner logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Gate selinux_modules_facts task output behind a verbosity-based no_log condition to reduce log noise during normal runs.