### PR TITLE
docs(changelog): version 1.12.1 [citest_skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+[1.12.1] - 2026-05-07
+--------------------
+
+### Bug Fixes
+
+- fix: add verbosity-based no_log to facts modules (#348)
+
+### Other Changes
+
+- ci: bump actions/github-script from 8 to 9 (#347)
+
 [1.12.0] - 2026-04-28
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.12.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Document release 1.12.1 in the changelog with its associated bug fix and CI workflow update.

Bug Fixes:
- Document fix for verbosity-based no_log handling in facts modules for version 1.12.1.

CI:
- Document CI update to actions/github-script version 9 in the 1.12.1 release notes.

Documentation:
- Add changelog entry for version 1.12.1 including bug fixes and CI changes.