### PR TITLE
refactor: use ansible.posix 2.1.X for EL7 compatibility [citest_skip]

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,6 +2,7 @@
 ---
 collections:
   - name: ansible.posix
+    version: '>=2.1.0,<2.2.0'
   - name: community.general
     version: '>=6.6.0,<12.0.0'
   - name: fedora.linux_system_roles


### PR DESCRIPTION
The recently released ansible.posix 2.2.0 does not work on EL7.
Pin the version of ansible.posix to 2.1.X.

NOTE: Even though this role might not support EL7, this update
is applied to all system roles for consistency.  Plus, when this
role is part of the system roles collection, all roles must use
the same version of ansible.posix - there is no way for a role
which is part of a collection to use a different version of a
dependency than the version used by the other roles.
