### PR TITLE
fix: Relax ansible.posix and community.general version constraints [citest_skip]

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,7 +2,5 @@
 ---
 collections:
   - name: ansible.posix
-    version: '>=2.1.0,<2.2.0'
   - name: community.general
-    version: '>=6.6.0,<12.0.0'
   - name: fedora.linux_system_roles

--- a/tests/vars/rh_distros_vars.yml
+++ b/tests/vars/rh_distros_vars.yml
@@ -18,3 +18,9 @@ __selinux_is_rh_distro: "{{ ansible_facts['distribution'] in __selinux_rh_distro
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
 __selinux_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __selinux_rh_distros_fedora }}"
+
+# Use these in conditionals to check if distro is Red Hat or clone of a specific major version
+__selinux_is_rh_distro_7: "{{ __selinux_is_rh_distro and ansible_facts['distribution_major_version'] == '7' }}"
+__selinux_is_rh_distro_8: "{{ __selinux_is_rh_distro and ansible_facts['distribution_major_version'] == '8' }}"
+__selinux_is_rh_distro_9: "{{ __selinux_is_rh_distro and ansible_facts['distribution_major_version'] == '9' }}"
+__selinux_is_rh_distro_10: "{{ __selinux_is_rh_distro and ansible_facts['distribution_major_version'] == '10' }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -42,4 +42,10 @@ __selinux_is_rh_distro: "{{ ansible_facts['distribution'] in __selinux_rh_distro
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
 __selinux_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __selinux_rh_distros_fedora }}"
+
+# Use these in conditionals to check if distro is Red Hat or clone of a specific major version
+__selinux_is_rh_distro_7: "{{ __selinux_is_rh_distro and ansible_facts['distribution_major_version'] == '7' }}"
+__selinux_is_rh_distro_8: "{{ __selinux_is_rh_distro and ansible_facts['distribution_major_version'] == '8' }}"
+__selinux_is_rh_distro_9: "{{ __selinux_is_rh_distro and ansible_facts['distribution_major_version'] == '9' }}"
+__selinux_is_rh_distro_10: "{{ __selinux_is_rh_distro and ansible_facts['distribution_major_version'] == '10' }}"
 # END - DO NOT EDIT THIS BLOCK - rh distros variables


### PR DESCRIPTION
Enhancement: Relax ansible.posix and community.general version constraints

Reason: The caps (ansible.posix <2.2.0, community.general <12.0.0) existed to preserve EL7 compatibility, but we now vendor EL7 modules, hence other distros can use latest versions.

Result: The role runs on EL7 managed nodes natively, and users can install latest community collections versions.
