### PR TITLE
fix: Select SELinux modules by managed node python version

### DIFF
--- a/library/seboolean_python_27.py
+++ b/library/seboolean_python_27.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r"""
 ---
-module: seboolean_ansible_29
+module: seboolean_python_27
 short_description: Toggles SELinux booleans
 description:
      - Toggles SELinux booleans.
@@ -49,7 +49,7 @@ author:
 
 EXAMPLES = r"""
 - name: Set httpd_can_network_connect flag on and keep it persistent across reboots
-  seboolean_ansible_29:
+  seboolean_python_27:
     name: httpd_can_network_connect
     state: true
     persistent: true

--- a/library/sefcontext_python_36.py
+++ b/library/sefcontext_python_36.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 DOCUMENTATION = r"""
-module: sefcontext_ansible_29
+module: sefcontext_python_36
 short_description: Manages SELinux file context mapping definitions
 description:
   - Manages SELinux file context mapping definitions.
@@ -97,25 +97,25 @@ author:
 
 EXAMPLES = r"""
 - name: Allow apache to modify files in /srv/git_repos
-  sefcontext_ansible_29:
+  sefcontext_python_36:
     target: '/srv/git_repos(/.*)?'
     setype: httpd_sys_rw_content_t
     state: present
 
 - name: Substitute file contexts for path /srv/containers with /var/lib/containers
-  sefcontext_ansible_29:
+  sefcontext_python_36:
     target: /srv/containers
     substitute: /var/lib/containers
     state: present
 
 - name: Delete file context path substitution for /srv/containers
-  sefcontext_ansible_29:
+  sefcontext_python_36:
     target: /srv/containers
     substitute: /var/lib/containers
     state: absent
 
 - name: Delete any file context mappings for path /srv/git
-  sefcontext_ansible_29:
+  sefcontext_python_36:
     target: /srv/git
     state: absent
 

--- a/library/selinux_python_27.py
+++ b/library/selinux_python_27.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r"""
 ---
-module: selinux_ansible_29
+module: selinux_python_27
 short_description: Change policy and state of SELinux
 description:
   - Configures the SELinux mode and policy.
@@ -48,17 +48,17 @@ author:
 
 EXAMPLES = r"""
 - name: Enable SELinux
-  selinux_ansible_29:
+  selinux_python_27:
     policy: targeted
     state: enforcing
 
 - name: Put SELinux in permissive mode, logging actions that would be blocked.
-  selinux_ansible_29:
+  selinux_python_27:
     policy: targeted
     state: permissive
 
 - name: Disable SELinux
-  selinux_ansible_29:
+  selinux_python_27:
     state: disabled
 """
 

--- a/library/selogin_python_36.py
+++ b/library/selogin_python_36.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 DOCUMENTATION = r"""
-module: selogin_ansible_29
+module: selogin_python_36
 short_description: Manages linux user to SELinux user mapping
 description:
   - Manages linux user to SELinux user mapping.
@@ -59,20 +59,20 @@ author:
 
 EXAMPLES = r"""
 - name: Modify the default user on the system to the guest_u user
-  selogin_ansible_29:
+  selogin_python_36:
     login: __default__
     seuser: guest_u
     state: present
 
 - name: Assign gijoe user on an MLS machine a range and to the staff_u user
-  selogin_ansible_29:
+  selogin_python_36:
     login: gijoe
     seuser: staff_u
     serange: SystemLow-Secret
     state: present
 
 - name: Assign all users in the engineering group to the staff_u user
-  selogin_ansible_29:
+  selogin_python_36:
     login: '%engineering'
     seuser: staff_u
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,23 +28,26 @@
       ansible_facts['distribution_major_version'] is version('8', '>=') and
       ansible_version.full is version('2.10', '>=') }}"
   block:
-    - name: Set permanent SELinux state if enabled - ansible 2.9
+    # On managed nodes with python 2 (EL7 with ansible 2.9, where the
+    # ansible.posix collection cannot be installed), use the dependency-free
+    # vendored selinux_python_27 module, which retains python 2 support.
+    - name: Set permanent SELinux state if enabled - python 2
       # noqa args[module]
-      selinux_ansible_29:
+      selinux_python_27:
         state: "{{ selinux_state | default(ansible_facts['selinux']['config_mode'], true) }}"
         policy: "{{ selinux_policy | default(ansible_facts['selinux']['type'], true) }}"
         update_kernel_param: "{{ true if __update_kernel_param else omit }}"
-      register: selinux_mod_output_enabled_ansible_29
+      register: selinux_mod_output_enabled_py2
       when:
-        - ansible_version.full is version('2.10', '<')
+        - ansible_facts['python_version'] is version('3', '<')
         - ansible_facts['selinux']['status'] == "enabled"
         - (not selinux_state is none and selinux_state | length > 0) or
           (not selinux_policy is none and selinux_policy | length > 0)
 
-    # Bare module name (not FQCN): on ansible 2.9 the collection is not
-    # installable and an unresolvable FQCN aborts play parsing even for a task
-    # skipped by "when". The bare name resolves to the ansible 2.9 builtin
-    # (skipped here) and redirects to the latest collection module elsewhere.
+    # Bare module name (not FQCN): an unresolvable FQCN aborts play parsing on
+    # ansible 2.9 even for a task skipped by "when", so the bare name is used.
+    # This runs only on managed nodes with python 3, where the bare name
+    # resolves to the latest ansible.posix.selinux.
     - name: Set permanent SELinux state if enabled
       # noqa args[module]
       selinux:  # noqa fqcn
@@ -53,28 +56,31 @@
         update_kernel_param: "{{ true if __update_kernel_param else omit }}"
       register: selinux_mod_output_enabled
       when:
-        - ansible_version.full is version('2.10', '>=')
+        - ansible_facts['python_version'] is version('3', '>=')
         - ansible_facts['selinux']['status'] == "enabled"
         - (not selinux_state is none and selinux_state | length > 0) or
           (not selinux_policy is none and selinux_policy | length > 0)
 
-    - name: Set permanent SELinux state if disabled - ansible 2.9
+    # On managed nodes with python 2 (EL7 with ansible 2.9, where the
+    # ansible.posix collection cannot be installed), use the dependency-free
+    # vendored selinux_python_27 module, which retains python 2 support.
+    - name: Set permanent SELinux state if disabled - python 2
       # noqa args[module]
-      selinux_ansible_29:
+      selinux_python_27:
         state: "{{ selinux_state }}"
         policy: "{{ selinux_policy | default('targeted', true) }}"
         update_kernel_param: "{{ true if __update_kernel_param else omit }}"
-      register: selinux_mod_output_disabled_ansible_29
+      register: selinux_mod_output_disabled_py2
       when:
-        - ansible_version.full is version('2.10', '<')
+        - ansible_facts['python_version'] is version('3', '<')
         - ansible_facts['selinux']['status'] == "disabled"
         - not selinux_state is none
         - selinux_state | length > 0
 
-    # Bare module name (not FQCN): on ansible 2.9 the collection is not
-    # installable and an unresolvable FQCN aborts play parsing even for a task
-    # skipped by "when". The bare name resolves to the ansible 2.9 builtin
-    # (skipped here) and redirects to the latest collection module elsewhere.
+    # Bare module name (not FQCN): an unresolvable FQCN aborts play parsing on
+    # ansible 2.9 even for a task skipped by "when", so the bare name is used.
+    # This runs only on managed nodes with python 3, where the bare name
+    # resolves to the latest ansible.posix.selinux.
     - name: Set permanent SELinux state if disabled
       # noqa args[module]
       selinux:  # noqa fqcn
@@ -83,22 +89,22 @@
         update_kernel_param: "{{ true if __update_kernel_param else omit }}"
       register: selinux_mod_output_disabled
       when:
-        - ansible_version.full is version('2.10', '>=')
+        - ansible_facts['python_version'] is version('3', '>=')
         - ansible_facts['selinux']['status'] == "disabled"
         - not selinux_state is none
         - selinux_state | length > 0
 
-    # Only one of the ansible 2.9 / non-2.9 tasks above runs; the other is
+    # Only one of the python 2 / python 3 tasks above runs; the other is
     # skipped and its (skipped) result would otherwise clobber a shared
     # register. Coalesce into the original variable names so downstream logic
     # is unchanged.
     - name: Consolidate SELinux state module output
       set_fact:
-        selinux_mod_output_enabled: "{{ selinux_mod_output_enabled_ansible_29
-          if not (selinux_mod_output_enabled_ansible_29.skipped | d(false))
+        selinux_mod_output_enabled: "{{ selinux_mod_output_enabled_py2
+          if not (selinux_mod_output_enabled_py2.skipped | d(false))
           else selinux_mod_output_enabled }}"
-        selinux_mod_output_disabled: "{{ selinux_mod_output_disabled_ansible_29
-          if not (selinux_mod_output_disabled_ansible_29.skipped | d(false))
+        selinux_mod_output_disabled: "{{ selinux_mod_output_disabled_py2
+          if not (selinux_mod_output_disabled_py2.skipped | d(false))
           else selinux_mod_output_disabled }}"
 
     - name: Set selinux_reboot_required
@@ -163,8 +169,11 @@
   when: selinux_logins_purge | bool
   changed_when: true
 
-- name: Set SELinux booleans - ansible 2.9
-  seboolean_ansible_29:
+# On managed nodes with python 2 (EL7 with ansible 2.9, where the
+# ansible.posix collection cannot be installed), use the dependency-free
+# vendored seboolean_python_27 module, which retains python 2 support.
+- name: Set SELinux booleans - python 2
+  seboolean_python_27:
     name: "{{ __selinux_item.name }}"
     state: "{{ __selinux_item.state }}"
     persistent: "{{ __selinux_item.persistent |
@@ -174,12 +183,12 @@
   loop_control:
     loop_var: __selinux_item
   when:
-    - ansible_version.full is version('2.10', '<')
+    - ansible_facts['python_version'] is version('3', '<')
 
-# Bare module name (not FQCN): on ansible 2.9 the collection is not
-# installable and an unresolvable FQCN aborts play parsing even for a task
-# skipped by "when". The bare name resolves to the ansible 2.9 builtin
-# (skipped here) and redirects to the latest collection module elsewhere.
+# Bare module name (not FQCN): an unresolvable FQCN aborts play parsing on
+# ansible 2.9 even for a task skipped by "when", so the bare name is used.
+# This runs only on managed nodes with python 3, where the bare name resolves
+# to the latest ansible.posix.seboolean.
 - name: Set SELinux booleans
   seboolean:  # noqa fqcn
     name: "{{ __selinux_item.name }}"
@@ -191,10 +200,13 @@
   loop_control:
     loop_var: __selinux_item
   when:
-    - ansible_version.full is version('2.10', '>=')
+    - ansible_facts['python_version'] is version('3', '>=')
 
-- name: Set SELinux file contexts - ansible 2.9
-  sefcontext_ansible_29:
+# On managed nodes with python < 3.7, the latest community.general.sefcontext
+# fails to import ("from __future__ import annotations" requires python >=
+# 3.7), so use the dependency-free vendored sefcontext_python_36 module.
+- name: Set SELinux file contexts - python 3.6
+  sefcontext_python_36:
     target: "{{ __selinux_item.target }}"
     setype: "{{ __selinux_item.setype }}"
     ftype: "{{ __selinux_item.ftype | default('a') }}"
@@ -206,12 +218,12 @@
   loop_control:
     loop_var: __selinux_item
   when:
-    - ansible_version.full is version('2.10', '<')
+    - not (ansible_facts['python_version'] is version('3.7', '>='))
 
-# Bare module name (not FQCN): on ansible 2.9 the collection is not
-# installable and an unresolvable FQCN aborts play parsing even for a task
-# skipped by "when". The bare name resolves to the ansible 2.9 builtin
-# (skipped here) and redirects to the latest collection module elsewhere.
+# Bare module name (not FQCN): an unresolvable FQCN aborts play parsing on
+# ansible 2.9 even for a task skipped by "when", so the bare name is used.
+# This runs only on managed nodes with python >= 3.7, where the bare name
+# resolves to the latest collection module.
 - name: Set SELinux file contexts
   sefcontext:  # noqa fqcn
     target: "{{ __selinux_item.target }}"
@@ -225,7 +237,7 @@
   loop_control:
     loop_var: __selinux_item
   when:
-    - ansible_version.full is version('2.10', '>=')
+    - ansible_facts['python_version'] is version('3.7', '>=')
 
 - name: Set an SELinux label on a port
   local_seport:
@@ -239,8 +251,11 @@
   loop_control:
     loop_var: __selinux_item
 
-- name: Set linux user to SELinux user mapping - ansible 2.9
-  selogin_ansible_29:
+# On managed nodes with python < 3.7, the latest community.general.selogin
+# fails to import ("from __future__ import annotations" requires python >=
+# 3.7), so use the dependency-free vendored selogin_python_36 module.
+- name: Set linux user to SELinux user mapping - python 3.6
+  selogin_python_36:
     login: "{{ __selinux_item.login }}"
     seuser: "{{ __selinux_item.seuser }}"
     serange: "{{ __selinux_item.serange | default('s0') }}"
@@ -252,12 +267,12 @@
   loop_control:
     loop_var: __selinux_item
   when:
-    - ansible_version.full is version('2.10', '<')
+    - not (ansible_facts['python_version'] is version('3.7', '>='))
 
-# Bare module name (not FQCN): on ansible 2.9 the collection is not
-# installable and an unresolvable FQCN aborts play parsing even for a task
-# skipped by "when". The bare name resolves to the ansible 2.9 builtin
-# (skipped here) and redirects to the latest collection module elsewhere.
+# Bare module name (not FQCN): an unresolvable FQCN aborts play parsing on
+# ansible 2.9 even for a task skipped by "when", so the bare name is used.
+# This runs only on managed nodes with python >= 3.7, where the bare name
+# resolves to the latest collection module.
 - name: Set linux user to SELinux user mapping
   selogin:  # noqa fqcn
     login: "{{ __selinux_item.login }}"
@@ -271,7 +286,7 @@
   loop_control:
     loop_var: __selinux_item
   when:
-    - ansible_version.full is version('2.10', '>=')
+    - ansible_facts['python_version'] is version('3.7', '>=')
 
 - name: Get SELinux modules facts
   selinux_modules_facts:

--- a/tests/library/selinux_ansible_29.py
+++ b/tests/library/selinux_ansible_29.py
@@ -1,1 +1,0 @@
-../../library/selinux_ansible_29.py

--- a/tests/library/selinux_python_27.py
+++ b/tests/library/selinux_python_27.py
@@ -1,0 +1,1 @@
+../../library/selinux_python_27.py

--- a/tests/tests_all_transitions.yml
+++ b/tests/tests_all_transitions.yml
@@ -44,32 +44,33 @@
           ansible_facts['distribution_major_version'] is version('8', '>=') and
           ansible_version.full is version('2.10', '>=') }}"
 
-    # ansible 2.9 (ansible-engine) uses the vendored selinux_ansible_29 module,
-    # since ansible.posix cannot be installed there; other systems use the bare
-    # selinux name, which redirects to the latest ansible.posix.selinux.
-    - name: Disable selinux and set kernel - ansible 2.9
-      selinux_ansible_29:
+    # Managed nodes with python 2 (EL7 with ansible 2.9, where ansible.posix
+    # cannot be installed) use the vendored selinux_python_27 module, which
+    # retains python 2 support; python 3 nodes use the bare selinux name, which
+    # redirects to the latest ansible.posix.selinux.
+    - name: Disable selinux and set kernel - python 2
+      selinux_python_27:
         state: disabled
         update_kernel_param: "{{ true if __test_update_kernel_param else omit }}"
-      register: __disable_result_ansible_29
-      when: ansible_version.full is version('2.10', '<')
+      register: __disable_result_py2
+      when: ansible_facts['python_version'] is version('3', '<')
 
     # Bare name (not FQCN): an unresolvable FQCN aborts play parsing on ansible
-    # 2.9 even when the task is skipped. The bare selinux name resolves to the
-    # ansible 2.9 builtin (skipped here) and redirects to ansible.posix.selinux
-    # elsewhere.
+    # 2.9 even when the task is skipped, so the bare name is used. This runs
+    # only on managed nodes with python 3, where the bare selinux name resolves
+    # to the latest ansible.posix.selinux.
     - name: Disable selinux and set kernel
       selinux:  # noqa fqcn
         state: disabled
         update_kernel_param: "{{ true if __test_update_kernel_param else omit }}"
-      register: __disable_result_non_ansible_29
-      when: ansible_version.full is version('2.10', '>=')
+      register: __disable_result_py3
+      when: ansible_facts['python_version'] is version('3', '>=')
 
     - name: Set disable result
       set_fact:
-        __disable_result: "{{ __disable_result_ansible_29
-          if ansible_version.full is version('2.10', '<')
-          else __disable_result_non_ansible_29 }}"
+        __disable_result: "{{ __disable_result_py2
+          if ansible_facts['python_version'] is version('3', '<')
+          else __disable_result_py3 }}"
 
     - name: Add selinux=0 to kernel args
       when:
@@ -105,25 +106,26 @@
     - name: Restore config
       include_tasks: selinux_config_restore.yml
 
-    # ansible 2.9 (ansible-engine) uses the vendored selinux_ansible_29 module,
-    # since ansible.posix cannot be installed there; other systems use the bare
-    # selinux name, which redirects to the latest ansible.posix.selinux.
-    - name: Re-enable selinux and set kernel if disabled - ansible 2.9
-      selinux_ansible_29:
+    # Managed nodes with python 2 (EL7 with ansible 2.9, where ansible.posix
+    # cannot be installed) use the vendored selinux_python_27 module, which
+    # retains python 2 support; python 3 nodes use the bare selinux name, which
+    # redirects to the latest ansible.posix.selinux.
+    - name: Re-enable selinux and set kernel if disabled - python 2
+      selinux_python_27:
         state: "{{ __state_before }}"
         policy: "{{ __type_before }}"
         update_kernel_param: "{{ true if ansible_facts['os_family'] == 'RedHat' and
           ansible_facts['distribution_major_version'] is version('8', '>=')
           else omit }}"
-      register: __enable_result_ansible_29
+      register: __enable_result_py2
       when:
         - __disable_result.reboot_required
-        - ansible_version.full is version('2.10', '<')
+        - ansible_facts['python_version'] is version('3', '<')
 
     # Bare name (not FQCN): an unresolvable FQCN aborts play parsing on ansible
-    # 2.9 even when the task is skipped. The bare selinux name resolves to the
-    # ansible 2.9 builtin (skipped here) and redirects to ansible.posix.selinux
-    # elsewhere.
+    # 2.9 even when the task is skipped, so the bare name is used. This runs
+    # only on managed nodes with python 3, where the bare selinux name resolves
+    # to the latest ansible.posix.selinux.
     - name: Re-enable selinux and set kernel if disabled
       selinux:  # noqa fqcn
         state: "{{ __state_before }}"
@@ -131,16 +133,16 @@
         update_kernel_param: "{{ true if ansible_facts['os_family'] == 'RedHat' and
           ansible_facts['distribution_major_version'] is version('8', '>=')
           else omit }}"
-      register: __enable_result_non_ansible_29
+      register: __enable_result_py3
       when:
         - __disable_result.reboot_required
-        - ansible_version.full is version('2.10', '>=')
+        - ansible_facts['python_version'] is version('3', '>=')
 
     - name: Set enable result
       set_fact:
-        __enable_result: "{{ __enable_result_ansible_29
-          if ansible_version.full is version('2.10', '<')
-          else __enable_result_non_ansible_29 }}"
+        __enable_result: "{{ __enable_result_py2
+          if ansible_facts['python_version'] is version('3', '<')
+          else __enable_result_py3 }}"
 
     - name: Remove selinux=0 from kernel args
       when:

--- a/tests/tests_all_transitions.yml
+++ b/tests/tests_all_transitions.yml
@@ -114,9 +114,7 @@
       selinux_python_27:
         state: "{{ __state_before }}"
         policy: "{{ __type_before }}"
-        update_kernel_param: "{{ true if ansible_facts['os_family'] == 'RedHat' and
-          ansible_facts['distribution_major_version'] is version('8', '>=')
-          else omit }}"
+        update_kernel_param: "{{ true if __test_update_kernel_param else omit }}"
       register: __enable_result_py2
       when:
         - __disable_result.reboot_required
@@ -130,9 +128,7 @@
       selinux:  # noqa fqcn
         state: "{{ __state_before }}"
         policy: "{{ __type_before }}"
-        update_kernel_param: "{{ true if ansible_facts['os_family'] == 'RedHat' and
-          ansible_facts['distribution_major_version'] is version('8', '>=')
-          else omit }}"
+        update_kernel_param: "{{ true if __test_update_kernel_param else omit }}"
       register: __enable_result_py3
       when:
         - __disable_result.reboot_required


### PR DESCRIPTION
Enhancement: Select the SELinux modules by the managed node's python version instead of the ansible version. Gate each task on `ansible_facts.python_version`:
- `ansible.posix` modules (`selinux`, `seboolean`): the vendored `*_python_27` module on python 2, and the bare name (redirecting to `ansible.posix`) on python 3.
- `community.general` modules (`sefcontext`, `selogin`): the vendored `*_python_36` module when python < 3.7, and the bare name (redirecting to `community.general`) when python >= 3.7.

Rename the vendored modules from `*_ansible_29` to `*_python_27`/`*_python_36` to reflect the latest python they back, gather the `python_version` fact subset, and update the tests accordingly.

Reason: The latest `community.general` modules use `from __future__ import annotations`, which requires python >= 3.7 and fails to import on managed nodes running python 3.6, regardless of the controller's ansible version. The vendored modules import only core `ansible.module_utils`, carry no collection dependency, and retain python 2 support, so they also cover ansible 2.9 hosts (e.g. EL7) where the collections cannot be installed. A fully-qualified name is avoided because an unresolvable FQCN aborts play parsing on ansible 2.9 even for a task skipped by `when`, so the bare name is used.

Result: The role runs the vendored `*_python_27`/`*_python_36` modules on old-python managed nodes (py2.7/py3.6, e.g. EL7/EL8) and the latest collection modules on nodes with newer python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SELinux task selection now adapts to the managed node’s Python version.
  * Improved compatibility for Python 2 and older Python 3 environments.
  * SELinux transition tests now use Python-version-based module selection.

* **Documentation**
  * Updated module names and usage examples to match the supported Python compatibility variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->